### PR TITLE
fix: disconnect cleans global routes in one invocation

### DIFF
--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -5,11 +5,8 @@ Real file I/O, real TOML parsing. No network required.
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 
 from tv import defaults as defaults_mod
 from tv.config import (
@@ -23,7 +20,6 @@ from tv.config import (
 from tv.vpn.base import TunnelConfig
 from tv.vpn.fortivpn import FortiVPNPlugin
 from tv.vpn.openvpn import OpenVPNPlugin
-from tv.vpn.singbox import SingBoxPlugin
 
 
 # =========================================================================

--- a/tests/integration/test_engine_flow.py
+++ b/tests/integration/test_engine_flow.py
@@ -14,7 +14,7 @@ import pytest
 from tv.engine import Engine
 from tv.logger import Logger
 from tv.net import NetManager
-from tv.vpn.base import TunnelConfig, VPNResult
+from tv.vpn.base import VPNResult
 
 
 @pytest.fixture

--- a/tv/disconnect.py
+++ b/tv/disconnect.py
@@ -39,12 +39,20 @@ def get_bypass_routes(defs: dict) -> dict:
     return defs.get("global", {}).get("bypass", {})
 
 
-def _cleanup_routes_and_ipv6(
+def cleanup_global_routes(
     net: NetManager,
     log: Optional[Logger],
     defs: dict,
+    *,
+    skip_dns_suffix: bool = False,
 ) -> None:
-    """Shared cleanup: VPN server routes + bypass routes + IPv6 restore."""
+    """Delete global VPN server routes, bypass routes, and DNS resolver files.
+
+    Called from engine.disconnect_all() and emergency disconnect.
+    Does NOT restore IPv6 - caller handles that separately.
+
+    skip_dns_suffix: skip domain_suffix resolver cleanup (engine._stop_dns_proxy handles it).
+    """
     routes_cfg = get_vpn_server_routes(defs)
     static_hosts = routes_cfg.get("hosts", [])
     resolve_hosts = routes_cfg.get("resolve", [])
@@ -78,26 +86,37 @@ def _cleanup_routes_and_ipv6(
             _safe(lambda n=network: net.delete_net_route(n), f"del bypass net {network}", log)
 
     # Cleanup domain_suffix resolver files and upstream DNS route
-    domain_suffix = bypass_cfg.get("domain_suffix", [])
-    upstream_dns = bypass_cfg.get("upstream_dns", "8.8.8.8")
-    if domain_suffix:
-        zones = [s.lstrip(".").rstrip(".") for s in domain_suffix if s.lstrip(".").rstrip(".")]
-        if zones:
-            print(f"🧹 {t('disc.deleting_dns_bypass')}")
-            _safe(lambda: net.cleanup_dns_resolver(zones), "del suffix resolvers", log)
-        _safe(
-            lambda: net.delete_host_route(upstream_dns),
-            f"del upstream DNS route {upstream_dns}", log,
-        )
+    # (skip when engine._stop_dns_proxy already handled this)
+    if not skip_dns_suffix:
+        domain_suffix = bypass_cfg.get("domain_suffix", [])
+        upstream_dns = bypass_cfg.get("upstream_dns", "8.8.8.8")
+        if domain_suffix:
+            zones = [s.lstrip(".").rstrip(".") for s in domain_suffix if s.lstrip(".").rstrip(".")]
+            if zones:
+                print(f"🧹 {t('disc.deleting_dns_bypass')}")
+                _safe(lambda: net.cleanup_dns_resolver(zones), "del suffix resolvers", log)
+            _safe(
+                lambda: net.delete_host_route(upstream_dns),
+                f"del upstream DNS route {upstream_dns}", log,
+            )
 
-    # Safety net: scan /etc/resolver/ for leftover tunnelvault files
-    def _scan_resolvers():
-        cleaned = net.cleanup_local_dns_resolvers()
-        if cleaned:
-            print(f"🧹 {t('disc.extra_resolvers', files=', '.join(cleaned))}")
-            if log:
-                log.log("INFO", f"Cleaned leftover resolvers: {cleaned}")
-    _safe(_scan_resolvers, "scan local resolvers", log)
+        # Safety net: scan /etc/resolver/ for leftover tunnelvault files
+        def _scan_resolvers():
+            cleaned = net.cleanup_local_dns_resolvers()
+            if cleaned:
+                print(f"🧹 {t('disc.extra_resolvers', files=', '.join(cleaned))}")
+                if log:
+                    log.log("INFO", f"Cleaned leftover resolvers: {cleaned}")
+        _safe(_scan_resolvers, "scan local resolvers", log)
+
+
+def _cleanup_routes_and_ipv6(
+    net: NetManager,
+    log: Optional[Logger],
+    defs: dict,
+) -> None:
+    """Shared cleanup: global routes + IPv6 restore."""
+    cleanup_global_routes(net, log, defs)
 
     print(f"🌐 {t('disc.restore_ipv6')}")
     _safe(lambda: net.restore_ipv6(), "restore IPv6", log)

--- a/tv/engine.py
+++ b/tv/engine.py
@@ -345,7 +345,14 @@ class Engine:
             self._fire("post_disconnect", tunnel=tcfg, plugin=plugin)
 
         self._stop_dns_proxy()
+
+        # Глобальные маршруты (vpn_server_routes, bypass) - без этого
+        # disconnect нужно вызывать дважды: daemon убивается, но routes остаются
+        disconnect.cleanup_global_routes(
+            self.net, self.log, self.defs, skip_dns_suffix=True,
+        )
         self.net.restore_ipv6()
+
         self._clean_watch_state()
 
     def _clean_watch_state(self) -> None:


### PR DESCRIPTION
## Summary
- `engine.disconnect_all()` now calls `cleanup_global_routes()` to delete VPN server routes and bypass routes
- Previously daemon SIGTERM cleaned per-tunnel routes but left global routes (vpn_server_routes, bypass), requiring a second disconnect
- Extracted `cleanup_global_routes()` from private `_cleanup_routes_and_ipv6()` in disconnect.py

Closes #9

## Test plan
- [x] `uv run pytest -x -q` - 934 passed
- [ ] Manual: connect with daemon, single `disconnect` should clean everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)