### PR TITLE
ci: add GitHub Actions workflow with telegram notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    tags: [v*]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - run: uv sync --extra dev
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Run tests
+        run: uv run pytest tests/ -x -q -n auto -m "not network"
+
+      - name: Notify Telegram - CI failed
+        if: failure()
+        uses: enyonee/telegram-notify-action@v1
+        with:
+          bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          status: failure
+          message: |
+            ❌ <b>TunnelVault</b> CI failed
+
+            Branch: <code>${{ github.head_ref || github.ref_name }}</code>
+            Commit: <code>${{ github.sha }}</code>
+            Author: ${{ github.actor }}
+
+            <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">View logs</a>
+
+  notify-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: lint-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname | sed -n '2p')
+          if [ -n "$PREV_TAG" ]; then
+            LOG=$(git log --oneline "$PREV_TAG".."${{ github.ref_name }}" | grep -v 'bump version' | head -15)
+          else
+            LOG=$(git log --oneline -10 "${{ github.ref_name }}" | head -15)
+          fi
+          {
+            echo 'log<<EOF'
+            echo "$LOG"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify Telegram - release
+        uses: enyonee/telegram-notify-action@v1
+        with:
+          bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          status: success
+          message: |
+            🚀 <b>TunnelVault</b> <code>${{ github.ref_name }}</code>
+
+            <b>Changes:</b>
+            <code>${{ steps.changelog.outputs.log }}</code>
+
+            <a href="${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}">Release</a>


### PR DESCRIPTION
## Summary
- Lint (ruff check + format) and test (pytest, 934 tests) on every PR to main
- Telegram notification on CI failure via `enyonee/telegram-notify-action@v1`
- Release notification on tag push (`v*`) with auto-generated changelog

## Secrets needed
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_CHAT_ID`

## Test plan
- [x] Add secrets to repo settings
- [x] Push a test tag to verify release notification
- [x] Create a PR with a lint error to verify failure notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)