### PR TITLE
fix: ocserv image + integration workflow fixes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,11 +82,15 @@ jobs:
       - name: Deploy VPN servers
         run: |
           TAG=${{ github.run_id }}
-          for f in k8s/test-vpn/openvpn-server.yaml k8s/test-vpn/ocserv.yaml k8s/test-vpn/singbox-server.yaml; do
-            sed "s/namespace: test-vpn/namespace: $NS/g; s/\.test-vpn/.$NS/g; s|:latest|:$TAG|g" "$f" | \
+          # Custom images (openvpn, ocserv) - replace tag
+          for f in k8s/test-vpn/openvpn-server.yaml k8s/test-vpn/ocserv.yaml; do
+            sed "s/namespace: test-vpn/namespace: $NS/g; s/\.test-vpn/.$NS/g; s|ghcr.io/enyonee/\(.*\):latest|ghcr.io/enyonee/\1:$TAG|g" "$f" | \
               $SSH "sudo kubectl apply -f -"
           done
-          # Patch imagePullSecrets
+          # sing-box uses upstream image, no tag replacement
+          sed "s/namespace: test-vpn/namespace: $NS/g; s/\.test-vpn/.$NS/g" k8s/test-vpn/singbox-server.yaml | \
+            $SSH "sudo kubectl apply -f -"
+          # Patch imagePullSecrets for custom images
           for deploy in openvpn-server ocserv; do
             $SSH "sudo kubectl patch deploy $deploy -n $NS -p '{\"spec\":{\"template\":{\"spec\":{\"imagePullSecrets\":[{\"name\":\"ghcr-pull\"}]}}}}'"
           done

--- a/k8s/test-vpn/Dockerfile.ocserv
+++ b/k8s/test-vpn/Dockerfile.ocserv
@@ -1,6 +1,8 @@
-FROM alpine:3.21
+FROM debian:bookworm-slim
 
-RUN apk add --no-cache ocserv gnutls-utils
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ocserv gnutls-bin \
+    && rm -rf /var/lib/apt/lists/*
 
 # Pre-generated test certs
 COPY k8s/test-vpn/pki/ocserv-ca.pem /etc/ocserv/ca.pem
@@ -8,7 +10,6 @@ COPY k8s/test-vpn/pki/ocserv-ca-key.pem /etc/ocserv/ca-key.pem
 COPY k8s/test-vpn/pki/ocserv-server.pem /etc/ocserv/server.pem
 COPY k8s/test-vpn/pki/ocserv-server-key.pem /etc/ocserv/server-key.pem
 
-# NS_PLACEHOLDER replaced by sed at deploy time
 RUN cat > /etc/ocserv/ocserv.conf <<'CONF'
 auth = "plain[passwd=/etc/ocserv/passwd]"
 tcp-port = 4443


### PR DESCRIPTION
## Summary
- Switch ocserv Dockerfile from Alpine (no ocserv package) to Debian bookworm-slim
- Fix singbox image tag - don't replace upstream `ghcr.io/sagernet/sing-box:latest` tag
- Separate deployment of custom vs upstream images in workflow

## Context
Follow-up to PR #24 merge. Integration tests failed because:
1. `ocserv` package doesn't exist in Alpine 3.21 for x86_64
2. `sed s|:latest|:$TAG|g` was replacing sing-box upstream image tag too

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)