### PR TITLE
refactor: centralize K8s test settings into config.env

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
+      # Все настройки - в одном месте. Canonical source: k8s/test-vpn/config.env
       NS: test-vpn-${{ github.run_id }}
+      TAG: ${{ github.run_id }}
+      IMAGE_REGISTRY: ghcr.io/enyonee
+      OPENVPN_IMAGE: tunnelvault-openvpn-server
+      OCSERV_IMAGE: tunnelvault-ocserv
+      TEST_IMAGE: tunnelvault-test
+      SINGBOX_IMAGE: ghcr.io/sagernet/sing-box:latest
+      OPENVPN_PORT: "1194"
+      OCSERV_PORT: "4443"
+      SINGBOX_SS_PORT: "8388"
+      OCSERV_USER: testuser
+      OCSERV_PASS: testpass
+      SINGBOX_SS_PASSWORD: test-password-12345
       SSH: ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -i ~/.ssh/deploy_key deploy@${{ secrets.VDS_HOST }}
     steps:
       - uses: actions/checkout@v4
@@ -34,18 +47,17 @@ jobs:
       - name: Build and push images
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          TAG=${{ github.run_id }}
 
-          docker build -t ghcr.io/enyonee/tunnelvault-openvpn-server:$TAG \
-            -f k8s/test-vpn/Dockerfile.openvpn-server .
-          docker build -t ghcr.io/enyonee/tunnelvault-ocserv:$TAG \
-            -f k8s/test-vpn/Dockerfile.ocserv .
-          docker build -t ghcr.io/enyonee/tunnelvault-test:$TAG \
-            -f k8s/test-vpn/Dockerfile.test-runner .
-
-          docker push ghcr.io/enyonee/tunnelvault-openvpn-server:$TAG
-          docker push ghcr.io/enyonee/tunnelvault-ocserv:$TAG
-          docker push ghcr.io/enyonee/tunnelvault-test:$TAG
+          declare -A IMAGES=(
+            [$OPENVPN_IMAGE]=Dockerfile.openvpn-server
+            [$OCSERV_IMAGE]=Dockerfile.ocserv
+            [$TEST_IMAGE]=Dockerfile.test-runner
+          )
+          for img in "${!IMAGES[@]}"; do
+            docker build -t $IMAGE_REGISTRY/$img:$TAG \
+              -f k8s/test-vpn/${IMAGES[$img]} .
+            docker push $IMAGE_REGISTRY/$img:$TAG
+          done
 
       - name: Create ephemeral namespace
         run: |
@@ -69,10 +81,8 @@ jobs:
 
       - name: Create client configs
         run: |
-          # OpenVPN client config with correct namespace
           sed "s/NS_PLACEHOLDER/$NS/g" k8s/test-vpn/pki/client.ovpn > /tmp/client.ovpn
 
-          # ocserv fingerprint
           FINGERPRINT=$(cat k8s/test-vpn/pki/ocserv-fingerprint.txt)
 
           $SSH "sudo kubectl create configmap vpn-client-configs -n $NS \
@@ -81,10 +91,9 @@ jobs:
 
       - name: Deploy VPN servers
         run: |
-          TAG=${{ github.run_id }}
-          # Custom images (openvpn, ocserv) - replace tag
+          # Custom images (openvpn, ocserv) - replace namespace + tag
           for f in k8s/test-vpn/openvpn-server.yaml k8s/test-vpn/ocserv.yaml; do
-            sed "s/namespace: test-vpn/namespace: $NS/g; s/\.test-vpn/.$NS/g; s|ghcr.io/enyonee/\(.*\):latest|ghcr.io/enyonee/\1:$TAG|g" "$f" | \
+            sed "s/namespace: test-vpn/namespace: $NS/g; s/\.test-vpn/.$NS/g; s|$IMAGE_REGISTRY/\(.*\):latest|$IMAGE_REGISTRY/\1:$TAG|g" "$f" | \
               $SSH "sudo kubectl apply -f -"
           done
           # sing-box uses upstream image, no tag replacement
@@ -109,10 +118,9 @@ jobs:
 
       - name: Run test Job
         run: |
-          TAG=${{ github.run_id }}
           sed -e "s/namespace: test-vpn/namespace: $NS/g" \
               -e "s/\.test-vpn/.$NS/g" \
-              -e "s|ghcr.io/enyonee/tunnelvault-test:latest|ghcr.io/enyonee/tunnelvault-test:$TAG|g" \
+              -e "s|$IMAGE_REGISTRY/$TEST_IMAGE:latest|$IMAGE_REGISTRY/$TEST_IMAGE:$TAG|g" \
               k8s/test-vpn/test-runner-job.yaml | \
             $SSH "sudo kubectl apply -f -"
 

--- a/k8s/test-vpn/config.env
+++ b/k8s/test-vpn/config.env
@@ -1,0 +1,49 @@
+# Центральный конфиг для K8s integration tests
+# Используется в: integration.yml, run-tests.sh
+# YAML-манифесты остаются шаблонами (namespace: test-vpn заменяется через sed)
+
+# --- Namespace ---
+NS_PREFIX=test-vpn
+
+# --- Docker images ---
+IMAGE_REGISTRY=ghcr.io/enyonee
+OPENVPN_IMAGE_NAME=tunnelvault-openvpn-server
+OCSERV_IMAGE_NAME=tunnelvault-ocserv
+TEST_RUNNER_IMAGE_NAME=tunnelvault-test
+SINGBOX_IMAGE=ghcr.io/sagernet/sing-box:latest
+
+# --- Порты сервисов ---
+OPENVPN_PORT=1194
+OCSERV_PORT=4443
+SINGBOX_SS_PORT=8388
+SINGBOX_SOCKS_PORT=1080
+SINGBOX_HTTP_PORT=8080
+
+# --- Credentials (тестовые, не секрет) ---
+OCSERV_USER=testuser
+OCSERV_PASS=testpass
+SINGBOX_SS_PASSWORD=test-password-12345
+
+# --- Таймауты ---
+WORKFLOW_TIMEOUT_MIN=25
+JOB_ACTIVE_DEADLINE=900
+JOB_TTL=3600
+DEPLOY_WAIT_TIMEOUT=120
+DEPLOY_POLL_MAX=40
+DEPLOY_POLL_INTERVAL=10
+TEST_POLL_MAX=60
+TEST_POLL_INTERVAL=15
+SVC_WAIT_RETRIES=30
+SVC_WAIT_INTERVAL=2
+
+# --- Resource limits ---
+# VPN server pods
+VPN_CPU_REQUEST=50m
+VPN_MEM_REQUEST=32Mi
+VPN_CPU_LIMIT=200m
+VPN_MEM_LIMIT=128Mi
+# Test runner pod
+TEST_CPU_REQUEST=200m
+TEST_MEM_REQUEST=256Mi
+TEST_CPU_LIMIT=500m
+TEST_MEM_LIMIT=512Mi

--- a/k8s/test-vpn/run-tests.sh
+++ b/k8s/test-vpn/run-tests.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-# Ephemeral integration test runner
+# Ephemeral integration test runner (local kubectl)
 # Creates namespace, deploys VPN servers, runs tests, cleans up
 # Usage: ./run-tests.sh [--keep]  (--keep to not delete namespace after)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Загружаем настройки из config.env
+# shellcheck source=config.env
+source "$SCRIPT_DIR/config.env"
+
 RUN_ID=$(date +%s)
-NS="test-vpn-${RUN_ID}"
+NS="${NS_PREFIX}-${RUN_ID}"
 KEEP=false
 
 [[ "${1:-}" == "--keep" ]] && KEEP=true
@@ -17,28 +22,26 @@ kubectl label namespace "$NS" env=test app=tunnelvault --overwrite
 
 # Apply policies and quotas (replace namespace in manifests)
 for f in network-policy.yaml resource-quota.yaml; do
-    sed "s/namespace: test-vpn/namespace: $NS/g" "$SCRIPT_DIR/$f" | kubectl apply -f -
+    sed "s/namespace: ${NS_PREFIX}/namespace: $NS/g" "$SCRIPT_DIR/$f" | kubectl apply -f -
 done
 
 # Deploy VPN servers (replace namespace)
 for f in openvpn-server.yaml ocserv.yaml singbox-server.yaml; do
-    sed "s/namespace: test-vpn/namespace: $NS/g" "$SCRIPT_DIR/$f" | kubectl apply -f -
+    sed "s/namespace: ${NS_PREFIX}/namespace: $NS/g; s/\.${NS_PREFIX}/.$NS/g" "$SCRIPT_DIR/$f" | kubectl apply -f -
 done
 
 echo "=== Waiting for VPN servers ==="
-kubectl wait --for=condition=Available deploy --all -n "$NS" --timeout=120s 2>/dev/null || true
+kubectl wait --for=condition=Available deploy --all -n "$NS" --timeout="${DEPLOY_WAIT_TIMEOUT}s" 2>/dev/null || true
 sleep 5
 
 echo "=== Running tests ==="
 # Create and run test Job
-sed -e "s/namespace: test-vpn/namespace: $NS/g" \
-    -e "s/openvpn-server\.test-vpn/openvpn-server.$NS/g" \
-    -e "s/ocserv\.test-vpn/ocserv.$NS/g" \
-    -e "s/singbox-server\.test-vpn/singbox-server.$NS/g" \
+sed -e "s/namespace: ${NS_PREFIX}/namespace: $NS/g" \
+    -e "s/\.${NS_PREFIX}/.$NS/g" \
     "$SCRIPT_DIR/test-runner-job.yaml" | kubectl apply -f -
 
 # Follow logs
-kubectl wait --for=condition=Ready pod -l job-name=tunnelvault-integration-test -n "$NS" --timeout=120s 2>/dev/null || true
+kubectl wait --for=condition=Ready pod -l job-name=tunnelvault-integration-test -n "$NS" --timeout="${DEPLOY_WAIT_TIMEOUT}s" 2>/dev/null || true
 kubectl logs -f -n "$NS" job/tunnelvault-integration-test 2>/dev/null || true
 
 # Get exit code


### PR DESCRIPTION
## Summary
- Новый `k8s/test-vpn/config.env` - единый источник настроек инфры и тестов
- Workflow `env:` блок ссылается на те же значения (namespace, образы, порты, credentials, таймауты)
- `run-tests.sh` source-ит config.env вместо хардкода
- Упрощён build step (цикл по ассоциативному массиву)
- sed-паттерны используют `$NS_PREFIX` / `$IMAGE_REGISTRY` вместо литералов

Closes #34

## Test plan
- [ ] Запустить integration tests через workflow_dispatch - всё должно работать как раньше