### PR TITLE
fix: inject bypass domain_suffix into sing-box route rules

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -11,6 +11,13 @@
 hosts = ["203.0.113.10", "203.0.113.20"]
 resolve = ["vpn.example.com"]
 
+# Bypass - домены/хосты, которые должны идти мимо VPN (через default GW).
+# domain_suffix инжектится в sing-box route rules как outbound "direct",
+# а также создает DNS proxy для корректного резолва через upstream_dns.
+# [global.bypass]
+# domain_suffix = [".ru", ".su", ".xn--p1ai"]
+# upstream_dns = "77.88.8.8"
+
 # === Туннели ===
 
 [tunnels.openvpn]

--- a/tests/test_vpn_singbox.py
+++ b/tests/test_vpn_singbox.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import platform
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from tv.vpn.base import TunnelConfig
-from tv.vpn.singbox import SingBoxPlugin
+from tv.vpn.singbox import SingBoxPlugin, _inject_bypass_rules
 
 pytestmark = pytest.mark.skipif(
     platform.system() == "Windows", reason="sing-box plugin is Unix-only"
@@ -269,3 +271,138 @@ class TestResolvedDefaults:
         r = plugin.connect()
         assert r.ok is False
         assert r.detail == "config not found"
+
+
+# =========================================================================
+# Bypass domain injection
+# =========================================================================
+
+
+class TestBypassInjection:
+    def _make_sb_config(self, tmp_dir: Path) -> Path:
+        """Create a minimal sing-box config with sniff and route rules."""
+        config = {
+            "log": {"level": "info"},
+            "inbounds": [
+                {
+                    "type": "tun",
+                    "tag": "tun-in",
+                    "interface_name": "utun98",
+                    "sniff": True,
+                }
+            ],
+            "outbounds": [
+                {"type": "trojan", "tag": "proxy", "server": "1.2.3.4"},
+                {"type": "direct", "tag": "direct"},
+            ],
+            "route": {
+                "auto_detect_interface": True,
+                "rules": [
+                    {"ip_cidr": ["5.5.5.5/32"], "outbound": "direct"},
+                ],
+                "final": "proxy",
+            },
+        }
+        path = tmp_dir / "test-sb.json"
+        path.write_text(json.dumps(config))
+        return path
+
+    def test_inject_adds_bypass_rule_first(self, tmp_dir, logger):
+        """Bypass rule is inserted as the first route rule."""
+        config_path = self._make_sb_config(tmp_dir)
+        suffixes = [".ru", ".su", ".vk.com"]
+
+        result = _inject_bypass_rules(config_path, suffixes, logger)
+        assert result is not None
+
+        patched = json.loads(Path(result).read_text())
+        rules = patched["route"]["rules"]
+        assert rules[0]["domain_suffix"] == ["ru", "su", "vk.com"]
+        assert rules[0]["outbound"] == "direct"
+        # Original rule still there
+        assert rules[1]["ip_cidr"] == ["5.5.5.5/32"]
+
+        Path(result).unlink()
+
+    def test_inject_normalizes_suffixes(self, tmp_dir, logger):
+        """Leading dots are stripped from suffixes."""
+        config_path = self._make_sb_config(tmp_dir)
+        suffixes = [".ru", "su", ".xn--p1ai."]
+
+        result = _inject_bypass_rules(config_path, suffixes, logger)
+        patched = json.loads(Path(result).read_text())
+        assert patched["route"]["rules"][0]["domain_suffix"] == [
+            "ru",
+            "su",
+            "xn--p1ai",
+        ]
+
+        Path(result).unlink()
+
+    def test_inject_empty_suffixes_returns_none(self, tmp_dir, logger):
+        """Empty suffix list returns None (no patching needed)."""
+        config_path = self._make_sb_config(tmp_dir)
+        assert _inject_bypass_rules(config_path, [], logger) is None
+
+    def test_inject_bad_json_returns_none(self, tmp_dir, logger):
+        """Invalid JSON config returns None without crashing."""
+        bad_path = tmp_dir / "bad.json"
+        bad_path.write_text("not json")
+        assert _inject_bypass_rules(bad_path, [".ru"], logger) is None
+
+    def test_inject_missing_route_section(self, tmp_dir, logger):
+        """Config without route section gets one created."""
+        config_path = tmp_dir / "no-route.json"
+        config_path.write_text('{"log":{"level":"info"}}')
+
+        result = _inject_bypass_rules(config_path, [".ru"], logger)
+        assert result is not None
+
+        patched = json.loads(Path(result).read_text())
+        assert patched["route"]["rules"][0]["domain_suffix"] == ["ru"]
+        assert patched["route"]["rules"][0]["outbound"] == "direct"
+
+        Path(result).unlink()
+
+    def test_connect_uses_patched_config(self, plugin, tmp_dir):
+        """connect() launches sing-box with patched config when bypass is set."""
+        # Create a proper sing-box config
+        sb_config = {
+            "log": {"level": "info"},
+            "route": {"rules": [], "final": "proxy"},
+            "outbounds": [{"type": "direct", "tag": "direct"}],
+        }
+        (tmp_dir / "singbox.json").write_text(json.dumps(sb_config))
+        plugin.cfg.extra["bypass_domain_suffix"] = [".ru"]
+
+        with _singbox_connect_ok(plugin) as mock_proc:
+            r = plugin.connect()
+
+        assert r.ok is True
+        # Check that run_background was called with patched config path
+        bg_call = mock_proc.run_background.call_args[0][0]
+        config_arg = bg_call[3]  # ["sing-box", "run", "-c", PATH]
+        assert "sb_bypass_" in config_arg
+
+    def test_disconnect_cleans_patched_config(self, plugin, tmp_dir):
+        """disconnect() removes the patched config file."""
+        sb_config = {
+            "log": {"level": "info"},
+            "route": {"rules": [], "final": "proxy"},
+            "outbounds": [{"type": "direct", "tag": "direct"}],
+        }
+        (tmp_dir / "singbox.json").write_text(json.dumps(sb_config))
+        plugin.cfg.extra["bypass_domain_suffix"] = [".ru"]
+
+        with _singbox_connect_ok(plugin):
+            plugin.connect()
+
+        patched_path = plugin._patched_config
+        assert patched_path is not None
+        assert Path(patched_path).exists()
+
+        with patch("tv.vpn.base.proc") as mock_proc:
+            mock_proc.is_alive.return_value = False
+            plugin.disconnect()
+
+        assert not Path(patched_path).exists()

--- a/tv/engine.py
+++ b/tv/engine.py
@@ -108,6 +108,15 @@ class Engine:
         self.results = []
         self.tunnels = defaults_mod.parse_tunnels(self.defs)
 
+        # Inject bypass domain_suffix into singbox tunnels so the plugin
+        # can add direct route rules into the sing-box JSON config.
+        bypass_cfg = get_bypass_routes(self.defs)
+        bypass_suffixes = bypass_cfg.get("domain_suffix", [])
+        if bypass_suffixes:
+            for tcfg in self.tunnels:
+                if tcfg.type == "singbox":
+                    tcfg.extra["bypass_domain_suffix"] = bypass_suffixes
+
         # Filter out tunnels whose binary is not installed
         self.tunnels = self._filter_available(self.tunnels)
         if not self.tunnels:

--- a/tv/vpn/singbox.py
+++ b/tv/vpn/singbox.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import os
+import tempfile
 from pathlib import Path
 
 from tv import proc, ui
@@ -20,6 +23,10 @@ class SingBoxPlugin(TunnelPlugin):
     type_display_name = "sing-box"
     process_names = ("sing-box",)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._patched_config: str | None = None
+
     @classmethod
     def emergency_patterns(cls, script_dir) -> list[str]:
         return [f"sing-box run -c {script_dir}"]
@@ -28,6 +35,10 @@ class SingBoxPlugin(TunnelPlugin):
     def discover_pid(cls, tcfg, script_dir) -> int | None:
         config_path = script_dir / tcfg.config_file
         pids = proc.find_pids(f"sing-box run -c {config_path}")
+        if pids:
+            return pids[0]
+        # Also check patched config pattern
+        pids = proc.find_pids(f"sing-box run -c {cfg.paths.temp_dir}/sb_bypass_")
         return pids[0] if pids else None
 
     @classmethod
@@ -60,10 +71,19 @@ class SingBoxPlugin(TunnelPlugin):
         if err := self._check_config_file("vpn.sb.config_not_found"):
             return err
 
+        # Inject bypass domain rules into sing-box config if configured
+        run_config = str(config_path)
+        bypass_suffixes = self.cfg.extra.get("bypass_domain_suffix", [])
+        if bypass_suffixes:
+            patched = _inject_bypass_rules(config_path, bypass_suffixes, self.log)
+            if patched:
+                run_config = patched
+                self._patched_config = patched
+
         # Launch in background
-        self.log.log("INFO", f"Launch: sudo sing-box run -c {config_path}")
+        self.log.log("INFO", f"Launch: sudo sing-box run -c {run_config}")
         sb_proc = proc.run_background(
-            ["sing-box", "run", "-c", str(config_path)],
+            ["sing-box", "run", "-c", run_config],
             sudo=True,
             log_path=str(log_path),
         )
@@ -98,9 +118,74 @@ class SingBoxPlugin(TunnelPlugin):
 
         return VPNResult(ok=True, pid=sb_pid)
 
+    def disconnect(self) -> None:
+        super().disconnect()
+        # Clean up patched config file
+        if self._patched_config:
+            try:
+                os.unlink(self._patched_config)
+            except OSError:
+                pass
+            self._patched_config = None
+
     def _kill_by_pattern(self) -> None:
         config_path = self.script_dir / self.cfg.config_file
         proc.kill_pattern(f"sing-box run -c {config_path}", sudo=True)
+        # Also kill by patched config pattern
+        if self._patched_config:
+            proc.kill_pattern(f"sing-box run -c {self._patched_config}", sudo=True)
+
+
+def _inject_bypass_rules(
+    config_path: Path,
+    suffixes: list[str],
+    log: Logger,
+) -> str | None:
+    """Inject bypass domain_suffix rules into sing-box JSON config.
+
+    Creates a temp file with domain_suffix rules added as the first route
+    rule with outbound "direct". Returns the temp file path, or None on error.
+    """
+    try:
+        data = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        log.log("WARN", f"bypass inject: cannot read {config_path}: {e}")
+        return None
+
+    # Normalize suffixes: ".ru" -> "ru", "vk.com" -> "vk.com"
+    normalized = [s.lstrip(".").rstrip(".") for s in suffixes if s.strip()]
+    if not normalized:
+        return None
+
+    # Build bypass rule
+    bypass_rule = {
+        "domain_suffix": normalized,
+        "outbound": "direct",
+    }
+
+    # Inject as first route rule (highest priority)
+    route = data.setdefault("route", {})
+    rules = route.setdefault("rules", [])
+    rules.insert(0, bypass_rule)
+
+    # Write patched config to temp file
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            prefix="sb_bypass_",
+            suffix=".json",
+            dir=cfg.paths.temp_dir,
+        )
+        os.write(fd, json.dumps(data, indent=2).encode())
+        os.close(fd)
+    except OSError as e:
+        log.log("WARN", f"bypass inject: cannot write temp config: {e}")
+        return None
+
+    log.log(
+        "INFO",
+        f"bypass inject: {len(normalized)} domain suffixes -> direct ({tmp_path})",
+    )
+    return tmp_path
 
 
 def _show_error(sb_proc, log_path: Path, log: Logger) -> None:


### PR DESCRIPTION
## Summary
- sing-box с `sniff: true` перехватывает трафик на TUN до системных маршрутов, поэтому `[global.bypass] domain_suffix` не работал
- Теперь domain_suffix inject'ится в sing-box JSON config как первое route rule с `outbound: "direct"`
- Temp-файл с patched config автоматически удаляется при disconnect

Closes #41

## Test plan
- [x] 7 новых unit-тестов для bypass injection
- [x] Все 403 теста pass
- [x] Линтер чистый
- [ ] Проверить на живой машине: `tvpn connect` с `.ru` доменами

🤖 Generated with [Claude Code](https://claude.com/claude-code)