### PR TITLE
feat: kill switch - block non-VPN traffic via firewall

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -6,6 +6,13 @@
 # Обязательное поле: type (openvpn | fortivpn | openconnect | singbox | wireguard)
 # Опциональные: order, enabled, config_file, log, interface, auth, routes, dns, checks
 
+# Kill switch - блокировка non-VPN трафика через firewall.
+# Если VPN падает, трафик не утечёт в открытую сеть.
+# macOS: pf anchor, Linux: iptables chain, Windows: netsh firewall rules.
+# --reset и --disconnect автоматически снимают правила.
+# [global]
+# kill_switch = true
+
 # Host routes к VPN-серверам через default GW (до старта туннелей)
 [global.vpn_server_routes]
 hosts = ["203.0.113.10", "203.0.113.20"]

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -1,0 +1,484 @@
+"""Tests for tv.killswitch: kill switch enable/disable and engine integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+from tv.killswitch import (
+    DarwinKillSwitch,
+    LinuxKillSwitch,
+    WindowsKillSwitch,
+    _build_pf_rules,
+    _PF_ANCHOR,
+    _IPTABLES_CHAIN,
+    _WIN_RULE_PREFIX,
+    create,
+)
+
+
+# =========================================================================
+# pf rule generation
+# =========================================================================
+
+
+class TestBuildPfRules:
+    def test_basic_rules(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=["utun99"],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=["5.6.7.8"],
+            bypass_networks=["10.0.0.0/8"],
+        )
+        assert "pass out quick on lo0 all" in rules
+        assert "pass out quick inet proto { tcp, udp } to 1.2.3.4" in rules
+        assert "pass out quick inet to 5.6.7.8" in rules
+        assert "pass out quick inet to 10.0.0.0/8" in rules
+        assert "pass out quick on utun99 all" in rules
+        assert "block out inet all" in rules
+
+    def test_dhcp_allowed(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=[],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        assert "port 68 to any port 67" in rules
+
+    def test_localhost_dns_allowed(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=[],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        assert "to 127.0.0.1 port 53" in rules
+
+    def test_multiple_interfaces(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=["utun99", "utun100", "tun0"],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        assert "pass out quick on utun99 all" in rules
+        assert "pass out quick on utun100 all" in rules
+        assert "pass out quick on tun0 all" in rules
+
+    def test_empty_lists(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=[],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        # Should still have loopback, DHCP, DNS, and block
+        assert "pass out quick on lo0 all" in rules
+        assert "block out inet all" in rules
+
+
+# =========================================================================
+# Darwin (pf) kill switch
+# =========================================================================
+
+
+class TestDarwinKillSwitch:
+    @patch("tv.killswitch._run")
+    def test_enable_loads_rules(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = DarwinKillSwitch()
+
+        # Mock reading /etc/pf.conf
+        pf_content = "# Default pf.conf\n"
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            mock_open.return_value.read = MagicMock(return_value=pf_content)
+            mock_open.return_value.readlines = MagicMock(return_value=[pf_content])
+
+            ok = ks.enable(
+                vpn_interfaces=["utun99"],
+                vpn_server_ips=["1.2.3.4"],
+                bypass_ips=[],
+                bypass_networks=[],
+            )
+
+        assert ok
+        assert ks.active
+        # Check pfctl was called with anchor load
+        pfctl_calls = [
+            c
+            for c in mock_run.call_args_list
+            if any("pfctl" in str(a) for a in c.args[0])
+        ]
+        assert len(pfctl_calls) >= 1
+
+    @patch("tv.killswitch._run")
+    def test_disable_flushes_anchor(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = DarwinKillSwitch()
+        ks._active = True
+
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            mock_open.return_value.readlines = MagicMock(return_value=[])
+
+            ok = ks.disable()
+
+        assert ok
+        assert not ks.active
+        # Should flush the anchor
+        flush_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "-F" in c.args[0] and _PF_ANCHOR in c.args[0]
+        ]
+        assert len(flush_calls) == 1
+
+
+# =========================================================================
+# Linux (iptables) kill switch
+# =========================================================================
+
+
+class TestLinuxKillSwitch:
+    @patch("tv.killswitch._run")
+    def test_enable_creates_chain(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+
+        ok = ks.enable(
+            vpn_interfaces=["tun0"],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=["5.6.7.8"],
+            bypass_networks=["10.0.0.0/8"],
+        )
+
+        assert ok
+        assert ks.active
+
+        # Verify chain creation
+        chain_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "-N" in c.args[0] and _IPTABLES_CHAIN in c.args[0]
+        ]
+        assert len(chain_calls) == 1
+
+        # Verify OUTPUT jump
+        jump_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "-I" in c.args[0] and "OUTPUT" in c.args[0]
+        ]
+        assert len(jump_calls) == 1
+
+        # Verify DROP at end
+        drop_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "-j" in c.args[0] and "DROP" in c.args[0]
+        ]
+        assert len(drop_calls) == 1
+
+    @patch("tv.killswitch._run")
+    def test_enable_allows_loopback(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+
+        ks.enable(
+            vpn_interfaces=[],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+
+        lo_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "-o" in c.args[0] and "lo" in c.args[0]
+        ]
+        assert len(lo_calls) >= 1
+
+    @patch("tv.killswitch._run")
+    def test_disable_removes_chain(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+        ks._active = True
+
+        ok = ks.disable()
+
+        assert ok
+        assert not ks.active
+
+        # Verify chain deletion
+        delete_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "-X" in c.args[0] and _IPTABLES_CHAIN in c.args[0]
+        ]
+        assert len(delete_calls) == 1
+
+    @patch("tv.killswitch._run")
+    def test_enable_cleans_previous_first(self, mock_run):
+        """Enable should flush any existing chain before creating new one."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+
+        ks.enable(
+            vpn_interfaces=["tun0"],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+
+        # Flush should come before create
+        all_args = [c.args[0] for c in mock_run.call_args_list]
+        flush_idx = next(
+            i for i, a in enumerate(all_args) if "-F" in a and _IPTABLES_CHAIN in a
+        )
+        create_idx = next(
+            i for i, a in enumerate(all_args) if "-N" in a and _IPTABLES_CHAIN in a
+        )
+        assert flush_idx < create_idx
+
+
+# =========================================================================
+# Windows (netsh) kill switch
+# =========================================================================
+
+
+class TestWindowsKillSwitch:
+    @patch("tv.killswitch._run")
+    def test_enable_creates_rules(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = WindowsKillSwitch()
+
+        ok = ks.enable(
+            vpn_interfaces=[],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+
+        assert ok
+        assert ks.active
+
+        # Verify block-all rule
+        block_calls = [
+            c
+            for c in mock_run.call_args_list
+            if f"{_WIN_RULE_PREFIX}-BlockAll" in str(c.args[0]) and "add" in c.args[0]
+        ]
+        assert len(block_calls) == 1
+
+    @patch("tv.killswitch._run")
+    def test_disable_removes_rules(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = WindowsKillSwitch()
+        ks._active = True
+
+        ok = ks.disable()
+
+        assert ok
+        assert not ks.active
+
+        # Verify delete calls for all rule types
+        delete_calls = [c for c in mock_run.call_args_list if "delete" in c.args[0]]
+        assert len(delete_calls) >= 2  # BlockAll + at least AllowLoopback
+
+
+# =========================================================================
+# Factory
+# =========================================================================
+
+
+class TestFactory:
+    @patch("tv.killswitch.platform.system", return_value="Darwin")
+    def test_darwin(self, _):
+        ks = create()
+        assert isinstance(ks, DarwinKillSwitch)
+
+    @patch("tv.killswitch.platform.system", return_value="Linux")
+    def test_linux(self, _):
+        ks = create()
+        assert isinstance(ks, LinuxKillSwitch)
+
+    @patch("tv.killswitch.platform.system", return_value="Windows")
+    def test_windows(self, _):
+        ks = create()
+        assert isinstance(ks, WindowsKillSwitch)
+
+
+# =========================================================================
+# Engine integration
+# =========================================================================
+
+
+class TestEngineIntegration:
+    """Test kill switch integration with Engine lifecycle."""
+
+    def test_setup_enables_kill_switch_when_configured(self, tmp_dir, mock_net, logger):
+        """Engine.setup() should enable kill switch if [global].kill_switch = true."""
+        defs = {
+            "global": {
+                "kill_switch": True,
+                "vpn_server_routes": {"hosts": ["1.2.3.4"]},
+            },
+            "tunnels": {
+                "sb": {
+                    "type": "singbox",
+                    "order": 1,
+                    "config_file": "singbox.json",
+                    "interface": "utun99",
+                },
+            },
+        }
+        _write_toml(tmp_dir, defs)
+
+        from tv.engine import Engine
+
+        engine = Engine(tmp_dir, defs, net=mock_net, log=logger)
+        engine.prepare()
+
+        with patch.object(
+            engine._killswitch, "enable", return_value=True
+        ) as mock_enable:
+            with patch("tv.engine.time.sleep"):
+                engine.setup()
+
+            mock_enable.assert_called_once()
+            args = mock_enable.call_args
+            assert "utun99" in args.kwargs["vpn_interfaces"]
+            assert "1.2.3.4" in args.kwargs["vpn_server_ips"]
+
+    def test_setup_skips_kill_switch_when_not_configured(
+        self, tmp_dir, mock_net, logger
+    ):
+        """Engine.setup() should NOT enable kill switch if not in config."""
+        defs = {
+            "tunnels": {
+                "sb": {
+                    "type": "singbox",
+                    "order": 1,
+                    "config_file": "singbox.json",
+                    "interface": "utun99",
+                },
+            },
+        }
+        _write_toml(tmp_dir, defs)
+
+        from tv.engine import Engine
+
+        engine = Engine(tmp_dir, defs, net=mock_net, log=logger)
+        engine.prepare()
+
+        with patch.object(engine._killswitch, "enable") as mock_enable:
+            with patch("tv.engine.time.sleep"):
+                engine.setup()
+
+            mock_enable.assert_not_called()
+
+    def test_disconnect_disables_kill_switch(self, tmp_dir, mock_net, logger):
+        """Engine.disconnect_all() should disable kill switch."""
+        defs = {
+            "global": {"kill_switch": True},
+            "tunnels": {
+                "sb": {
+                    "type": "singbox",
+                    "order": 1,
+                    "config_file": "singbox.json",
+                    "interface": "utun99",
+                },
+            },
+        }
+        _write_toml(tmp_dir, defs)
+
+        from tv.engine import Engine
+
+        engine = Engine(tmp_dir, defs, net=mock_net, log=logger)
+        engine.prepare()
+
+        # Simulate active kill switch
+        engine._killswitch._active = True
+
+        with patch.object(engine._killswitch, "disable") as mock_disable:
+            engine.disconnect_all()
+            mock_disable.assert_called_once()
+
+    def test_disconnect_skips_when_not_active(self, tmp_dir, mock_net, logger):
+        """disconnect_all() should not call disable if kill switch was never enabled."""
+        defs = {
+            "tunnels": {
+                "sb": {
+                    "type": "singbox",
+                    "order": 1,
+                    "config_file": "singbox.json",
+                    "interface": "utun99",
+                },
+            },
+        }
+        _write_toml(tmp_dir, defs)
+
+        from tv.engine import Engine
+
+        engine = Engine(tmp_dir, defs, net=mock_net, log=logger)
+        engine.prepare()
+
+        with patch.object(engine._killswitch, "disable") as mock_disable:
+            engine.disconnect_all()
+            mock_disable.assert_not_called()
+
+
+# =========================================================================
+# Config parsing
+# =========================================================================
+
+
+class TestConfigParsing:
+    def test_get_kill_switch_enabled_true(self):
+        from tv.disconnect import get_kill_switch_enabled
+
+        defs = {"global": {"kill_switch": True}}
+        assert get_kill_switch_enabled(defs) is True
+
+    def test_get_kill_switch_enabled_false(self):
+        from tv.disconnect import get_kill_switch_enabled
+
+        defs = {"global": {"kill_switch": False}}
+        assert get_kill_switch_enabled(defs) is False
+
+    def test_get_kill_switch_missing(self):
+        from tv.disconnect import get_kill_switch_enabled
+
+        assert get_kill_switch_enabled({}) is False
+        assert get_kill_switch_enabled({"global": {}}) is False
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _write_toml(tmp_dir, defs):
+    """Write minimal config.toml for engine tests."""
+    import tomlkit
+
+    doc = tomlkit.document()
+    if "tunnels" in defs:
+        t_section = tomlkit.table(is_super_table=True)
+        for name, tdata in defs["tunnels"].items():
+            t_table = tomlkit.table()
+            for k, v in tdata.items():
+                if isinstance(v, dict):
+                    sub = tomlkit.table()
+                    for sk, sv in v.items():
+                        sub[sk] = sv
+                    t_table[k] = sub
+                else:
+                    t_table[k] = v
+            t_section[name] = t_table
+        doc["tunnels"] = t_section
+    (tmp_dir / "config.toml").write_text(tomlkit.dumps(doc))

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -13,8 +13,67 @@ from tv.killswitch import (
     _PF_ANCHOR,
     _IPTABLES_CHAIN,
     _WIN_RULE_PREFIX,
+    _is_valid_ip,
+    _is_valid_network,
+    _is_valid_iface,
+    _sanitize_ips,
+    _sanitize_networks,
+    _sanitize_ifaces,
     create,
 )
+
+
+# =========================================================================
+# Input sanitization
+# =========================================================================
+
+
+class TestSanitization:
+    def test_valid_ips(self):
+        assert _is_valid_ip("1.2.3.4")
+        assert _is_valid_ip("192.168.1.1")
+        assert _is_valid_ip("255.255.255.255")
+
+    def test_invalid_ips(self):
+        assert not _is_valid_ip("1.2.3.4/32")
+        assert not _is_valid_ip("not-an-ip")
+        assert not _is_valid_ip("1.2.3.4; pass out all")
+        assert not _is_valid_ip("")
+        assert not _is_valid_ip("10.0.0.0/8")
+
+    def test_valid_networks(self):
+        assert _is_valid_network("10.0.0.0/8")
+        assert _is_valid_network("192.168.1.0/24")
+        assert _is_valid_network("0.0.0.0/0")
+
+    def test_invalid_networks(self):
+        assert not _is_valid_network("not-a-network")
+        assert not _is_valid_network("10.0.0.0; DROP TABLE")
+        assert not _is_valid_network("")
+
+    def test_valid_ifaces(self):
+        assert _is_valid_iface("utun99")
+        assert _is_valid_iface("tun0")
+        assert _is_valid_iface("ppp0")
+        assert _is_valid_iface("en0")
+
+    def test_invalid_ifaces(self):
+        assert not _is_valid_iface("tun0; rm -rf /")
+        assert not _is_valid_iface("tun 0")
+        assert not _is_valid_iface("")
+        assert not _is_valid_iface("tun\n0")
+
+    def test_sanitize_ips_filters(self):
+        result = _sanitize_ips(["1.2.3.4", "bad; stuff", "5.6.7.8"])
+        assert result == ["1.2.3.4", "5.6.7.8"]
+
+    def test_sanitize_networks_filters(self):
+        result = _sanitize_networks(["10.0.0.0/8", "bad", "192.168.0.0/16"])
+        assert result == ["10.0.0.0/8", "192.168.0.0/16"]
+
+    def test_sanitize_ifaces_filters(self):
+        result = _sanitize_ifaces(["utun99", "bad iface", "tun0"])
+        assert result == ["utun99", "tun0"]
 
 
 # =========================================================================

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -12,6 +12,7 @@ from tv.killswitch import (
     _build_pf_rules,
     _PF_ANCHOR,
     _IPTABLES_CHAIN,
+    _IPTABLES_CHAIN_IN,
     _WIN_RULE_PREFIX,
     _is_valid_ip,
     _is_valid_network,
@@ -89,12 +90,16 @@ class TestBuildPfRules:
             bypass_ips=["5.6.7.8"],
             bypass_networks=["10.0.0.0/8"],
         )
-        assert "pass out quick on lo0 all" in rules
+        # Outbound
+        assert "pass quick on lo0 all" in rules
         assert "pass out quick inet proto { tcp, udp } to 1.2.3.4" in rules
         assert "pass out quick inet to 5.6.7.8" in rules
         assert "pass out quick inet to 10.0.0.0/8" in rules
-        assert "pass out quick on utun99 all" in rules
+        assert "pass quick on utun99 all" in rules
         assert "block out inet all" in rules
+        # Inbound
+        assert "pass in quick inet proto { tcp, udp } from 1.2.3.4" in rules
+        assert "block in inet all" in rules
 
     def test_dhcp_allowed(self):
         rules = _build_pf_rules(
@@ -121,9 +126,9 @@ class TestBuildPfRules:
             bypass_ips=[],
             bypass_networks=[],
         )
-        assert "pass out quick on utun99 all" in rules
-        assert "pass out quick on utun100 all" in rules
-        assert "pass out quick on tun0 all" in rules
+        assert "pass quick on utun99 all" in rules
+        assert "pass quick on utun100 all" in rules
+        assert "pass quick on tun0 all" in rules
 
     def test_empty_lists(self):
         rules = _build_pf_rules(
@@ -132,9 +137,10 @@ class TestBuildPfRules:
             bypass_ips=[],
             bypass_networks=[],
         )
-        # Should still have loopback, DHCP, DNS, and block
-        assert "pass out quick on lo0 all" in rules
+        # Should still have loopback, DHCP, DNS, and block (both directions)
+        assert "pass quick on lo0 all" in rules
         assert "block out inet all" in rules
+        assert "block in inet all" in rules
 
 
 # =========================================================================
@@ -218,29 +224,30 @@ class TestLinuxKillSwitch:
         assert ok
         assert ks.active
 
-        # Verify chain creation
+        # Verify both chains created (OUTPUT + INPUT)
         chain_calls = [
             c
             for c in mock_run.call_args_list
-            if "-N" in c.args[0] and _IPTABLES_CHAIN in c.args[0]
+            if "-N" in c.args[0]
+            and (_IPTABLES_CHAIN in c.args[0] or _IPTABLES_CHAIN_IN in c.args[0])
         ]
-        assert len(chain_calls) == 1
+        assert len(chain_calls) == 2
 
-        # Verify OUTPUT jump
+        # Verify OUTPUT and INPUT jumps
         jump_calls = [
             c
             for c in mock_run.call_args_list
-            if "-I" in c.args[0] and "OUTPUT" in c.args[0]
+            if "-I" in c.args[0] and ("OUTPUT" in c.args[0] or "INPUT" in c.args[0])
         ]
-        assert len(jump_calls) == 1
+        assert len(jump_calls) == 2
 
-        # Verify DROP at end
+        # Verify DROP rules (one per chain)
         drop_calls = [
             c
             for c in mock_run.call_args_list
             if "-j" in c.args[0] and "DROP" in c.args[0]
         ]
-        assert len(drop_calls) == 1
+        assert len(drop_calls) == 2
 
     @patch("tv.killswitch._run")
     def test_enable_allows_loopback(self, mock_run):
@@ -272,13 +279,14 @@ class TestLinuxKillSwitch:
         assert ok
         assert not ks.active
 
-        # Verify chain deletion
+        # Verify both chains deleted
         delete_calls = [
             c
             for c in mock_run.call_args_list
-            if "-X" in c.args[0] and _IPTABLES_CHAIN in c.args[0]
+            if "-X" in c.args[0]
+            and (_IPTABLES_CHAIN in c.args[0] or _IPTABLES_CHAIN_IN in c.args[0])
         ]
-        assert len(delete_calls) == 1
+        assert len(delete_calls) == 2
 
     @patch("tv.killswitch._run")
     def test_enable_cleans_previous_first(self, mock_run):
@@ -325,13 +333,15 @@ class TestWindowsKillSwitch:
         assert ok
         assert ks.active
 
-        # Verify block-all rule
+        # Verify block rules (outbound + inbound)
         block_calls = [
             c
             for c in mock_run.call_args_list
-            if f"{_WIN_RULE_PREFIX}-BlockAll" in str(c.args[0]) and "add" in c.args[0]
+            if "Block" in str(c.args[0])
+            and "add" in c.args[0]
+            and _WIN_RULE_PREFIX in str(c.args[0])
         ]
-        assert len(block_calls) == 1
+        assert len(block_calls) == 2  # BlockAll (out) + BlockAllIn (in)
 
     @patch("tv.killswitch._run")
     def test_disable_removes_rules(self, mock_run):

--- a/tv/disconnect.py
+++ b/tv/disconnect.py
@@ -39,6 +39,11 @@ def get_bypass_routes(defs: dict) -> dict:
     return defs.get("global", {}).get("bypass", {})
 
 
+def get_kill_switch_enabled(defs: dict) -> bool:
+    """Check if kill switch is enabled in config."""
+    return bool(defs.get("global", {}).get("kill_switch", False))
+
+
 def cleanup_global_routes(
     net: NetManager,
     log: Optional[Logger],
@@ -133,7 +138,13 @@ def _cleanup_routes_and_ipv6(
     log: Optional[Logger],
     defs: dict,
 ) -> None:
-    """Shared cleanup: global routes + IPv6 restore."""
+    """Shared cleanup: global routes + kill switch + IPv6 restore."""
+    # Disable kill switch before restoring routes
+    from tv.killswitch import create as create_killswitch
+
+    ks = create_killswitch(log)
+    _safe(lambda: ks.disable(), "disable kill switch", log)
+
     cleanup_global_routes(net, log, defs)
 
     print(f"🌐 {t('disc.restore_ipv6')}")

--- a/tv/engine.py
+++ b/tv/engine.py
@@ -11,8 +11,13 @@ from typing import Callable, Optional
 
 from tv import config, ui, disconnect, checks, proc
 from tv.app_config import cfg
-from tv.disconnect import get_vpn_server_routes, get_bypass_routes
+from tv.disconnect import (
+    get_vpn_server_routes,
+    get_bypass_routes,
+    get_kill_switch_enabled,
+)
 from tv import defaults as defaults_mod
+from tv.killswitch import KillSwitch, create as create_killswitch
 from tv.dns_proxy import BypassDNSProxy
 from tv.i18n import t
 from tv.logger import Logger
@@ -80,6 +85,7 @@ class Engine:
         self._dns_proxy: Optional[BypassDNSProxy] = None
         self._dns_proxy_zones: list[str] = []
         self._dns_proxy_upstream: str = ""
+        self._killswitch: KillSwitch = create_killswitch(self.log)
 
     # --- Hooks ---
 
@@ -208,6 +214,9 @@ class Engine:
         self._setup_vpn_server_routes(gw, quiet=quiet)
         self._setup_bypass_routes(gw, quiet=quiet)
         self._start_dns_proxy(gw, quiet=quiet)
+
+        # Enable kill switch (before connect, after routes are set up)
+        self._enable_kill_switch(quiet=quiet)
 
         # Pre-create log files with correct ownership (readable without sudo)
         config.prepare_log_files(self.tunnels)
@@ -493,6 +502,7 @@ class Engine:
             ui.info(f"🌐 {t('main.proxy_removed')}")
 
         self._stop_dns_proxy()
+        self._disable_kill_switch()
 
         if cfg.mode != "proxy-only":
             # Глобальные маршруты (vpn_server_routes, bypass) - без этого
@@ -688,6 +698,43 @@ class Engine:
         self._dns_proxy = None
         self._dns_proxy_zones = []
         self._dns_proxy_upstream = ""
+
+    def _enable_kill_switch(self, *, quiet: bool = False) -> None:
+        """Enable kill switch if configured in [global]."""
+        if not get_kill_switch_enabled(self.defs):
+            return
+
+        # Collect VPN interfaces from tunnel configs
+        vpn_interfaces = [tc.interface for tc in self.tunnels if tc.interface]
+
+        # Collect VPN server IPs (static + resolved)
+        routes_cfg = get_vpn_server_routes(self.defs)
+        vpn_server_ips = list(routes_cfg.get("hosts", []))
+        for hostname in routes_cfg.get("resolve", []):
+            vpn_server_ips.extend(self.net.resolve_host(hostname))
+
+        # Collect bypass IPs/networks
+        bypass_cfg = get_bypass_routes(self.defs)
+        bypass_ips = list(bypass_cfg.get("hosts", []))
+        for hostname in bypass_cfg.get("domains", []):
+            bypass_ips.extend(self.net.resolve_host(hostname))
+        bypass_networks = list(bypass_cfg.get("networks", []))
+
+        ok = self._killswitch.enable(
+            vpn_interfaces=vpn_interfaces,
+            vpn_server_ips=vpn_server_ips,
+            bypass_ips=bypass_ips,
+            bypass_networks=bypass_networks,
+        )
+        if ok and not quiet:
+            ui.info(f"🛡 {t('engine.kill_switch_enabled')}")
+        elif not ok:
+            ui.warn(t("engine.kill_switch_failed"))
+
+    def _disable_kill_switch(self) -> None:
+        """Disable kill switch if active."""
+        if self._killswitch.active:
+            self._killswitch.disable()
 
     @staticmethod
     def _suffix_zones(suffixes: list[str]) -> list[str]:

--- a/tv/killswitch.py
+++ b/tv/killswitch.py
@@ -11,12 +11,70 @@ Platform implementations:
 
 from __future__ import annotations
 
+import ipaddress
 import platform
+import re
 from abc import ABC, abstractmethod
 from typing import Optional
 
 from tv.logger import Logger
 from tv.net import _run
+
+
+def _is_valid_ip(s: str) -> bool:
+    """Validate IPv4 address (no CIDR)."""
+    try:
+        ipaddress.IPv4Address(s)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_network(s: str) -> bool:
+    """Validate IPv4 network in CIDR notation."""
+    try:
+        ipaddress.IPv4Network(s, strict=False)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_iface(s: str) -> bool:
+    """Validate interface name (alphanumeric + limited symbols)."""
+    return bool(re.match(r"^[a-zA-Z0-9_-]+$", s))
+
+
+def _sanitize_ips(ips: list[str], log_fn=None) -> list[str]:
+    """Filter list to valid IPs only, log rejected."""
+    result = []
+    for ip in ips:
+        if _is_valid_ip(ip):
+            result.append(ip)
+        elif log_fn:
+            log_fn("WARN", f"rejected invalid IP: {ip!r}")
+    return result
+
+
+def _sanitize_networks(nets: list[str], log_fn=None) -> list[str]:
+    """Filter list to valid CIDR networks only, log rejected."""
+    result = []
+    for n in nets:
+        if _is_valid_network(n):
+            result.append(n)
+        elif log_fn:
+            log_fn("WARN", f"rejected invalid network: {n!r}")
+    return result
+
+
+def _sanitize_ifaces(ifaces: list[str], log_fn=None) -> list[str]:
+    """Filter list to valid interface names only, log rejected."""
+    result = []
+    for i in ifaces:
+        if _is_valid_iface(i):
+            result.append(i)
+        elif log_fn:
+            log_fn("WARN", f"rejected invalid interface: {i!r}")
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -54,6 +112,22 @@ class KillSwitch(ABC):
         if self.log:
             self.log.log(level, f"killswitch: {msg}")
 
+    def _sanitize(
+        self,
+        *,
+        vpn_interfaces: list[str],
+        vpn_server_ips: list[str],
+        bypass_ips: list[str],
+        bypass_networks: list[str],
+    ) -> tuple[list[str], list[str], list[str], list[str]]:
+        """Validate and filter all inputs before passing to firewall commands."""
+        return (
+            _sanitize_ifaces(vpn_interfaces, self._log),
+            _sanitize_ips(vpn_server_ips, self._log),
+            _sanitize_ips(bypass_ips, self._log),
+            _sanitize_networks(bypass_networks, self._log),
+        )
+
 
 # ---------------------------------------------------------------------------
 # macOS - pf anchor
@@ -73,6 +147,12 @@ class DarwinKillSwitch(KillSwitch):
         bypass_ips: list[str],
         bypass_networks: list[str],
     ) -> bool:
+        vpn_interfaces, vpn_server_ips, bypass_ips, bypass_networks = self._sanitize(
+            vpn_interfaces=vpn_interfaces,
+            vpn_server_ips=vpn_server_ips,
+            bypass_ips=bypass_ips,
+            bypass_networks=bypass_networks,
+        )
         rules = _build_pf_rules(
             vpn_interfaces=vpn_interfaces,
             vpn_server_ips=vpn_server_ips,
@@ -211,6 +291,12 @@ class LinuxKillSwitch(KillSwitch):
         bypass_ips: list[str],
         bypass_networks: list[str],
     ) -> bool:
+        vpn_interfaces, vpn_server_ips, bypass_ips, bypass_networks = self._sanitize(
+            vpn_interfaces=vpn_interfaces,
+            vpn_server_ips=vpn_server_ips,
+            bypass_ips=bypass_ips,
+            bypass_networks=bypass_networks,
+        )
         # Clean up any previous rules first
         self._flush_chain()
 
@@ -283,22 +369,7 @@ class LinuxKillSwitch(KillSwitch):
             ]
         )
 
-        # Allow VPN interfaces
-        for iface in vpn_interfaces:
-            _run(
-                [
-                    "sudo",
-                    "iptables",
-                    "-A",
-                    _IPTABLES_CHAIN,
-                    "-o",
-                    iface,
-                    "-j",
-                    "ACCEPT",
-                ]
-            )
-            # Also allow tun+ and utun+ wildcard for dynamic interfaces
-        # Wildcard patterns for interface families commonly used by VPNs
+        # Allow VPN interface families (tun+, ppp+ wildcards cover all instances)
         for prefix in ("tun+", "ppp+"):
             _run(
                 [
@@ -358,6 +429,12 @@ class WindowsKillSwitch(KillSwitch):
         bypass_ips: list[str],
         bypass_networks: list[str],
     ) -> bool:
+        vpn_interfaces, vpn_server_ips, bypass_ips, bypass_networks = self._sanitize(
+            vpn_interfaces=vpn_interfaces,
+            vpn_server_ips=vpn_server_ips,
+            bypass_ips=bypass_ips,
+            bypass_networks=bypass_networks,
+        )
         # Clean up previous rules
         self.disable()
 

--- a/tv/killswitch.py
+++ b/tv/killswitch.py
@@ -241,9 +241,11 @@ def _build_pf_rules(
     """Build pf rules for kill switch anchor."""
     lines: list[str] = [
         "# tunnelvault kill switch - auto-generated, do not edit",
-        "# Allow loopback",
-        "pass out quick on lo0 all",
+        "# Allow loopback (in + out)",
+        "pass quick on lo0 all",
     ]
+
+    # --- Outbound rules ---
 
     # Allow traffic to VPN server IPs (needed to establish tunnel)
     for ip in vpn_server_ips:
@@ -263,12 +265,22 @@ def _build_pf_rules(
     # Allow DNS to localhost (for local DNS proxy)
     lines.append("pass out quick inet proto { tcp, udp } to 127.0.0.1 port 53")
 
-    # Allow all traffic through VPN interfaces
+    # Allow all traffic through VPN interfaces (in + out)
     for iface in vpn_interfaces:
-        lines.append(f"pass out quick on {iface} all")
+        lines.append(f"pass quick on {iface} all")
 
-    # Block everything else
+    # --- Inbound rules ---
+
+    # Allow inbound from VPN server IPs (tunnel establishment responses)
+    for ip in vpn_server_ips:
+        lines.append(f"pass in quick inet proto {{ tcp, udp }} from {ip}")
+
+    # Allow DHCP responses
+    lines.append("pass in quick inet proto udp from any port 67 to any port 68")
+
+    # Block everything else (out + in)
     lines.append("block out inet all")
+    lines.append("block in inet all")
 
     return "\n".join(lines) + "\n"
 
@@ -278,10 +290,11 @@ def _build_pf_rules(
 # ---------------------------------------------------------------------------
 
 _IPTABLES_CHAIN = "TUNNELVAULT_KS"
+_IPTABLES_CHAIN_IN = "TUNNELVAULT_KS_IN"
 
 
 class LinuxKillSwitch(KillSwitch):
-    """Linux kill switch using iptables chain on OUTPUT."""
+    """Linux kill switch using iptables chains on OUTPUT and INPUT."""
 
     def enable(
         self,
@@ -384,11 +397,82 @@ class LinuxKillSwitch(KillSwitch):
                 ]
             )
 
-        # Drop everything else
+        # Drop everything else (OUTPUT)
         _run(["sudo", "iptables", "-A", _IPTABLES_CHAIN, "-j", "DROP"])
 
         # Insert jump to our chain at the top of OUTPUT
         _run(["sudo", "iptables", "-I", "OUTPUT", "1", "-j", _IPTABLES_CHAIN])
+
+        # --- INPUT chain: block unsolicited inbound on non-VPN interfaces ---
+        _run(["sudo", "iptables", "-N", _IPTABLES_CHAIN_IN])
+
+        # Allow loopback inbound
+        _run(
+            [
+                "sudo",
+                "iptables",
+                "-A",
+                _IPTABLES_CHAIN_IN,
+                "-i",
+                "lo",
+                "-j",
+                "ACCEPT",
+            ]
+        )
+
+        # Allow inbound on VPN interface families
+        for prefix in ("tun+", "ppp+"):
+            _run(
+                [
+                    "sudo",
+                    "iptables",
+                    "-A",
+                    _IPTABLES_CHAIN_IN,
+                    "-i",
+                    prefix,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+
+        # Allow inbound from VPN server IPs (tunnel handshake)
+        for ip in vpn_server_ips:
+            _run(
+                [
+                    "sudo",
+                    "iptables",
+                    "-A",
+                    _IPTABLES_CHAIN_IN,
+                    "-s",
+                    ip,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+
+        # Allow DHCP responses
+        _run(
+            [
+                "sudo",
+                "iptables",
+                "-A",
+                _IPTABLES_CHAIN_IN,
+                "-p",
+                "udp",
+                "--sport",
+                "67",
+                "--dport",
+                "68",
+                "-j",
+                "ACCEPT",
+            ]
+        )
+
+        # Drop everything else (INPUT)
+        _run(["sudo", "iptables", "-A", _IPTABLES_CHAIN_IN, "-j", "DROP"])
+
+        # Insert jump to our chain at the top of INPUT
+        _run(["sudo", "iptables", "-I", "INPUT", "1", "-j", _IPTABLES_CHAIN_IN])
 
         self._active = True
         self._log("INFO", "enabled (iptables)")
@@ -401,14 +485,19 @@ class LinuxKillSwitch(KillSwitch):
         return ok
 
     def _flush_chain(self) -> bool:
-        """Remove jump rule and flush/delete the chain."""
-        # Remove jump from OUTPUT (may fail if not present - ok)
+        """Remove jump rules and flush/delete both chains."""
+        # Remove jumps (may fail if not present - ok)
         _run(["sudo", "iptables", "-D", "OUTPUT", "-j", _IPTABLES_CHAIN])
-        # Flush chain
+        _run(["sudo", "iptables", "-D", "INPUT", "-j", _IPTABLES_CHAIN_IN])
+        # Flush and delete OUTPUT chain
         _run(["sudo", "iptables", "-F", _IPTABLES_CHAIN])
-        # Delete chain
-        r = _run(["sudo", "iptables", "-X", _IPTABLES_CHAIN])
-        return r.returncode == 0 or "No chain" in (r.stderr or "")
+        r1 = _run(["sudo", "iptables", "-X", _IPTABLES_CHAIN])
+        # Flush and delete INPUT chain
+        _run(["sudo", "iptables", "-F", _IPTABLES_CHAIN_IN])
+        r2 = _run(["sudo", "iptables", "-X", _IPTABLES_CHAIN_IN])
+        ok1 = r1.returncode == 0 or "No chain" in (r1.stderr or "")
+        ok2 = r2.returncode == 0 or "No chain" in (r2.stderr or "")
+        return ok1 and ok2
 
 
 # ---------------------------------------------------------------------------
@@ -521,12 +610,77 @@ class WindowsKillSwitch(KillSwitch):
             ]
         )
 
+        # --- Inbound rules ---
+
+        # Block all inbound by default
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-BlockAllIn",
+                "dir=in",
+                "action=block",
+                "protocol=any",
+            ]
+        )
+
+        # Allow inbound on loopback
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-AllowLoopbackIn",
+                "dir=in",
+                "action=allow",
+                "remoteip=127.0.0.0/8",
+            ]
+        )
+
+        # Allow inbound from VPN server IPs
+        if vpn_server_ips:
+            _run(
+                [
+                    "netsh",
+                    "advfirewall",
+                    "firewall",
+                    "add",
+                    "rule",
+                    f"name={_WIN_RULE_PREFIX}-AllowVPNServersIn",
+                    "dir=in",
+                    "action=allow",
+                    f"remoteip={','.join(vpn_server_ips)}",
+                ]
+            )
+
+        # Allow DHCP responses
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-AllowDHCPIn",
+                "dir=in",
+                "action=allow",
+                "protocol=udp",
+                "localport=68",
+                "remoteport=67",
+            ]
+        )
+
         self._active = True
         self._log("INFO", "enabled (netsh)")
         return True
 
     def disable(self) -> bool:
-        # Delete all rules with our prefix
+        # Delete all rules with our prefix (outbound + inbound)
         _run(
             [
                 "netsh",
@@ -537,7 +691,16 @@ class WindowsKillSwitch(KillSwitch):
                 f"name={_WIN_RULE_PREFIX}-BlockAll",
             ]
         )
-        for suffix in ("AllowLoopback", "AllowVPNServers", "AllowBypass", "AllowDHCP"):
+        for suffix in (
+            "AllowLoopback",
+            "AllowVPNServers",
+            "AllowBypass",
+            "AllowDHCP",
+            "BlockAllIn",
+            "AllowLoopbackIn",
+            "AllowVPNServersIn",
+            "AllowDHCPIn",
+        ):
             _run(
                 [
                     "netsh",

--- a/tv/killswitch.py
+++ b/tv/killswitch.py
@@ -1,0 +1,492 @@
+"""Kill switch: block non-VPN traffic via platform firewall rules.
+
+When enabled, only traffic through VPN interfaces and to VPN server IPs
+is allowed. If the VPN process dies, traffic does not leak to the open network.
+
+Platform implementations:
+- macOS: pf (Packet Filter) anchor
+- Linux: iptables chain
+- Windows: Windows Firewall via netsh
+"""
+
+from __future__ import annotations
+
+import platform
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from tv.logger import Logger
+from tv.net import _run
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class KillSwitch(ABC):
+    """Platform-agnostic kill switch interface."""
+
+    def __init__(self, log: Optional[Logger] = None) -> None:
+        self.log = log
+        self._active = False
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @abstractmethod
+    def enable(
+        self,
+        *,
+        vpn_interfaces: list[str],
+        vpn_server_ips: list[str],
+        bypass_ips: list[str],
+        bypass_networks: list[str],
+    ) -> bool:
+        """Apply firewall rules. Returns True on success."""
+
+    @abstractmethod
+    def disable(self) -> bool:
+        """Remove firewall rules. Returns True on success."""
+
+    def _log(self, level: str, msg: str) -> None:
+        if self.log:
+            self.log.log(level, f"killswitch: {msg}")
+
+
+# ---------------------------------------------------------------------------
+# macOS - pf anchor
+# ---------------------------------------------------------------------------
+
+_PF_ANCHOR = "com.tunnelvault.killswitch"
+
+
+class DarwinKillSwitch(KillSwitch):
+    """macOS kill switch using pf (Packet Filter) anchor."""
+
+    def enable(
+        self,
+        *,
+        vpn_interfaces: list[str],
+        vpn_server_ips: list[str],
+        bypass_ips: list[str],
+        bypass_networks: list[str],
+    ) -> bool:
+        rules = _build_pf_rules(
+            vpn_interfaces=vpn_interfaces,
+            vpn_server_ips=vpn_server_ips,
+            bypass_ips=bypass_ips,
+            bypass_networks=bypass_networks,
+        )
+
+        # Load rules into anchor
+        r = _run(
+            ["sudo", "pfctl", "-a", _PF_ANCHOR, "-f", "/dev/stdin"],
+            input=rules,
+        )
+        if r.returncode != 0:
+            self._log("ERROR", f"pfctl load failed: {r.stderr}")
+            return False
+
+        # Ensure anchor is referenced in main ruleset
+        if not self._ensure_anchor_ref():
+            self._log("WARN", "anchor reference not added, rules may not apply")
+
+        # Enable pf if not already enabled
+        _run(["sudo", "pfctl", "-e"])
+
+        self._active = True
+        self._log("INFO", f"enabled ({len(rules.splitlines())} rules)")
+        return True
+
+    def disable(self) -> bool:
+        # Flush anchor rules
+        r = _run(["sudo", "pfctl", "-a", _PF_ANCHOR, "-F", "all"])
+        ok = r.returncode == 0
+
+        # Remove anchor reference from main ruleset
+        self._remove_anchor_ref()
+
+        self._active = False
+        self._log("INFO", "disabled")
+        return ok
+
+    def _ensure_anchor_ref(self) -> bool:
+        """Add anchor reference to /etc/pf.conf if not present."""
+        anchor_line = f'anchor "{_PF_ANCHOR}"'
+        try:
+            with open("/etc/pf.conf") as f:
+                content = f.read()
+            if anchor_line in content:
+                return True
+        except OSError:
+            return False
+
+        # Append anchor reference
+        new_content = content.rstrip("\n") + f"\n{anchor_line}\n"
+        r = _run(["sudo", "tee", "/etc/pf.conf"], input=new_content)
+        if r.returncode != 0:
+            return False
+
+        # Reload main ruleset
+        _run(["sudo", "pfctl", "-f", "/etc/pf.conf"])
+        return True
+
+    def _remove_anchor_ref(self) -> None:
+        """Remove anchor reference from /etc/pf.conf."""
+        anchor_line = f'anchor "{_PF_ANCHOR}"'
+        try:
+            with open("/etc/pf.conf") as f:
+                lines = f.readlines()
+        except OSError:
+            return
+
+        filtered = [line for line in lines if anchor_line not in line]
+        if len(filtered) == len(lines):
+            return  # nothing to remove
+
+        r = _run(["sudo", "tee", "/etc/pf.conf"], input="".join(filtered))
+        if r.returncode == 0:
+            _run(["sudo", "pfctl", "-f", "/etc/pf.conf"])
+
+
+def _build_pf_rules(
+    *,
+    vpn_interfaces: list[str],
+    vpn_server_ips: list[str],
+    bypass_ips: list[str],
+    bypass_networks: list[str],
+) -> str:
+    """Build pf rules for kill switch anchor."""
+    lines: list[str] = [
+        "# tunnelvault kill switch - auto-generated, do not edit",
+        "# Allow loopback",
+        "pass out quick on lo0 all",
+    ]
+
+    # Allow traffic to VPN server IPs (needed to establish tunnel)
+    for ip in vpn_server_ips:
+        lines.append(f"pass out quick inet proto {{ tcp, udp }} to {ip}")
+
+    # Allow bypass IPs
+    for ip in bypass_ips:
+        lines.append(f"pass out quick inet to {ip}")
+
+    # Allow bypass networks
+    for net in bypass_networks:
+        lines.append(f"pass out quick inet to {net}")
+
+    # Allow DHCP (needed to get/renew IP)
+    lines.append("pass out quick inet proto udp from any port 68 to any port 67")
+
+    # Allow DNS to localhost (for local DNS proxy)
+    lines.append("pass out quick inet proto { tcp, udp } to 127.0.0.1 port 53")
+
+    # Allow all traffic through VPN interfaces
+    for iface in vpn_interfaces:
+        lines.append(f"pass out quick on {iface} all")
+
+    # Block everything else
+    lines.append("block out inet all")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Linux - iptables chain
+# ---------------------------------------------------------------------------
+
+_IPTABLES_CHAIN = "TUNNELVAULT_KS"
+
+
+class LinuxKillSwitch(KillSwitch):
+    """Linux kill switch using iptables chain on OUTPUT."""
+
+    def enable(
+        self,
+        *,
+        vpn_interfaces: list[str],
+        vpn_server_ips: list[str],
+        bypass_ips: list[str],
+        bypass_networks: list[str],
+    ) -> bool:
+        # Clean up any previous rules first
+        self._flush_chain()
+
+        # Create chain
+        _run(["sudo", "iptables", "-N", _IPTABLES_CHAIN])
+
+        # Allow loopback
+        _run(["sudo", "iptables", "-A", _IPTABLES_CHAIN, "-o", "lo", "-j", "ACCEPT"])
+
+        # Allow VPN server IPs
+        for ip in vpn_server_ips:
+            _run(
+                [
+                    "sudo",
+                    "iptables",
+                    "-A",
+                    _IPTABLES_CHAIN,
+                    "-d",
+                    ip,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+
+        # Allow bypass IPs
+        for ip in bypass_ips:
+            _run(
+                [
+                    "sudo",
+                    "iptables",
+                    "-A",
+                    _IPTABLES_CHAIN,
+                    "-d",
+                    ip,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+
+        # Allow bypass networks
+        for net in bypass_networks:
+            _run(
+                [
+                    "sudo",
+                    "iptables",
+                    "-A",
+                    _IPTABLES_CHAIN,
+                    "-d",
+                    net,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+
+        # Allow DHCP
+        _run(
+            [
+                "sudo",
+                "iptables",
+                "-A",
+                _IPTABLES_CHAIN,
+                "-p",
+                "udp",
+                "--sport",
+                "68",
+                "--dport",
+                "67",
+                "-j",
+                "ACCEPT",
+            ]
+        )
+
+        # Allow VPN interfaces
+        for iface in vpn_interfaces:
+            _run(
+                [
+                    "sudo",
+                    "iptables",
+                    "-A",
+                    _IPTABLES_CHAIN,
+                    "-o",
+                    iface,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+            # Also allow tun+ and utun+ wildcard for dynamic interfaces
+        # Wildcard patterns for interface families commonly used by VPNs
+        for prefix in ("tun+", "ppp+"):
+            _run(
+                [
+                    "sudo",
+                    "iptables",
+                    "-A",
+                    _IPTABLES_CHAIN,
+                    "-o",
+                    prefix,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+
+        # Drop everything else
+        _run(["sudo", "iptables", "-A", _IPTABLES_CHAIN, "-j", "DROP"])
+
+        # Insert jump to our chain at the top of OUTPUT
+        _run(["sudo", "iptables", "-I", "OUTPUT", "1", "-j", _IPTABLES_CHAIN])
+
+        self._active = True
+        self._log("INFO", "enabled (iptables)")
+        return True
+
+    def disable(self) -> bool:
+        ok = self._flush_chain()
+        self._active = False
+        self._log("INFO", "disabled (iptables)")
+        return ok
+
+    def _flush_chain(self) -> bool:
+        """Remove jump rule and flush/delete the chain."""
+        # Remove jump from OUTPUT (may fail if not present - ok)
+        _run(["sudo", "iptables", "-D", "OUTPUT", "-j", _IPTABLES_CHAIN])
+        # Flush chain
+        _run(["sudo", "iptables", "-F", _IPTABLES_CHAIN])
+        # Delete chain
+        r = _run(["sudo", "iptables", "-X", _IPTABLES_CHAIN])
+        return r.returncode == 0 or "No chain" in (r.stderr or "")
+
+
+# ---------------------------------------------------------------------------
+# Windows - netsh advfirewall
+# ---------------------------------------------------------------------------
+
+_WIN_RULE_PREFIX = "TunnelVault-KS"
+
+
+class WindowsKillSwitch(KillSwitch):
+    """Windows kill switch using netsh advfirewall rules."""
+
+    def enable(
+        self,
+        *,
+        vpn_interfaces: list[str],
+        vpn_server_ips: list[str],
+        bypass_ips: list[str],
+        bypass_networks: list[str],
+    ) -> bool:
+        # Clean up previous rules
+        self.disable()
+
+        # Block all outbound by default
+        r = _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-BlockAll",
+                "dir=out",
+                "action=block",
+                "protocol=any",
+            ]
+        )
+        if r.returncode != 0:
+            self._log("ERROR", f"block-all rule failed: {r.stderr}")
+            return False
+
+        # Allow loopback
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-AllowLoopback",
+                "dir=out",
+                "action=allow",
+                "remoteip=127.0.0.0/8",
+            ]
+        )
+
+        # Allow VPN server IPs
+        if vpn_server_ips:
+            _run(
+                [
+                    "netsh",
+                    "advfirewall",
+                    "firewall",
+                    "add",
+                    "rule",
+                    f"name={_WIN_RULE_PREFIX}-AllowVPNServers",
+                    "dir=out",
+                    "action=allow",
+                    f"remoteip={','.join(vpn_server_ips)}",
+                ]
+            )
+
+        # Allow bypass IPs and networks
+        allow_list = bypass_ips + bypass_networks
+        if allow_list:
+            _run(
+                [
+                    "netsh",
+                    "advfirewall",
+                    "firewall",
+                    "add",
+                    "rule",
+                    f"name={_WIN_RULE_PREFIX}-AllowBypass",
+                    "dir=out",
+                    "action=allow",
+                    f"remoteip={','.join(allow_list)}",
+                ]
+            )
+
+        # Allow DHCP
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-AllowDHCP",
+                "dir=out",
+                "action=allow",
+                "protocol=udp",
+                "localport=68",
+                "remoteport=67",
+            ]
+        )
+
+        self._active = True
+        self._log("INFO", "enabled (netsh)")
+        return True
+
+    def disable(self) -> bool:
+        # Delete all rules with our prefix
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "delete",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-BlockAll",
+            ]
+        )
+        for suffix in ("AllowLoopback", "AllowVPNServers", "AllowBypass", "AllowDHCP"):
+            _run(
+                [
+                    "netsh",
+                    "advfirewall",
+                    "firewall",
+                    "delete",
+                    "rule",
+                    f"name={_WIN_RULE_PREFIX}-{suffix}",
+                ]
+            )
+
+        self._active = False
+        self._log("INFO", "disabled (netsh)")
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create(log: Optional[Logger] = None) -> KillSwitch:
+    """Create platform-appropriate KillSwitch instance."""
+    system = platform.system()
+    if system == "Darwin":
+        return DarwinKillSwitch(log)
+    if system == "Windows":
+        return WindowsKillSwitch(log)
+    return LinuxKillSwitch(log)

--- a/tv/lang/en.py
+++ b/tv/lang/en.py
@@ -112,6 +112,8 @@ STRINGS: dict[str, str] = {
     "engine.settings_incomplete": "Settings incomplete, starting wizard...",
     "engine.binary_not_found": "'{binary}' not found, skipping profile '{name}' (install the package to use it)",
     "engine.no_available_tunnels": "No tunnels available - all required VPN packages are missing",
+    "engine.kill_switch_enabled": "Kill switch enabled (non-VPN traffic blocked)",
+    "engine.kill_switch_failed": "Kill switch failed to enable",
     # --- disconnect.py ---
     "disc.deleting_routes": "Deleting routes...",
     "disc.deleting_bypass": "Deleting bypass routes...",

--- a/tv/lang/ru.py
+++ b/tv/lang/ru.py
@@ -112,6 +112,8 @@ STRINGS: dict[str, str] = {
     "engine.settings_incomplete": "Настройки неполные, запускаю wizard...",
     "engine.binary_not_found": "'{binary}' не найден, пропускаю профиль '{name}' (установите пакет для использования)",
     "engine.no_available_tunnels": "Нет доступных туннелей - все необходимые VPN-пакеты отсутствуют",
+    "engine.kill_switch_enabled": "Kill switch включен (non-VPN трафик заблокирован)",
+    "engine.kill_switch_failed": "Kill switch не удалось включить",
     # --- disconnect.py ---
     "disc.deleting_routes": "Удаляю маршруты...",
     "disc.deleting_bypass": "Удаляю bypass-маршруты...",

--- a/uv.lock
+++ b/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "tunnelvault"
-version = "1.4.0"
+version = "1.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dnslib" },


### PR DESCRIPTION
## Summary
- Kill switch blocks all non-VPN traffic through platform-specific firewall rules when VPN is active
- macOS: pf anchor, Linux: iptables chain, Windows: netsh advfirewall rules
- Config: `[global] kill_switch = true` (default false)
- Auto-cleanup on `--disconnect`, `--reset`, and normal shutdown

## Changed files
- `tv/killswitch.py` - new module with `DarwinKillSwitch`, `LinuxKillSwitch`, `WindowsKillSwitch`
- `tv/engine.py` - enable in `setup()`, disable in `disconnect_all()`
- `tv/disconnect.py` - cleanup in `--reset`/`--disconnect` paths
- `config.toml.example` - documented `kill_switch` option
- `tv/lang/{en,ru}.py` - i18n strings

## Test plan
- [x] 23 unit tests for killswitch module (rule generation, enable/disable per platform, factory, engine integration, config parsing)
- [x] Full test suite: 1041 passed
- [x] Lint clean (ruff check + format)
- [ ] Manual test on macOS with pf
- [ ] Manual test on Linux with iptables

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)