### PR TITLE
feat: SSH tunnel plugin (SOCKS + sshuttle)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -87,6 +87,20 @@ services:
       vpn-e2e:
         ipv4_address: 172.28.0.13
 
+  ssh-server:
+    build:
+      context: .
+      dockerfile: tests/e2e/Dockerfile.ssh-server
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "22"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      vpn-e2e:
+        ipv4_address: 172.28.0.15
+
   test-runner:
     build:
       context: .
@@ -112,6 +126,10 @@ services:
       - FORTINET_PASS=testpass
       - WIREGUARD_SERVER=wireguard-server
       - WIREGUARD_PORT=51820
+      - SSH_SERVER=ssh-server
+      - SSH_PORT=22
+      - SSH_USER=testuser
+      - SSH_PASS=testpass
       - TUN_AVAILABLE=${TUN_AVAILABLE:-0}
     depends_on:
       openvpn-server:
@@ -123,6 +141,8 @@ services:
       fake-fortinet:
         condition: service_healthy
       wireguard-server:
+        condition: service_healthy
+      ssh-server:
         condition: service_healthy
     networks:
       vpn-e2e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ import tv.vpn.openvpn as _ovpn  # noqa: F401,E402
 import tv.vpn.fortivpn as _forti  # noqa: F401,E402
 import tv.vpn.singbox as _sb  # noqa: F401,E402
 import tv.vpn.wireguard as _wg  # noqa: F401,E402
+import tv.vpn.sshtunnel as _ssh  # noqa: F401,E402
 
 
 @pytest.fixture

--- a/tests/e2e/Dockerfile.ssh-server
+++ b/tests/e2e/Dockerfile.ssh-server
@@ -1,0 +1,11 @@
+FROM alpine:3.21
+RUN apk add --no-cache openssh-server openssh-sftp-server
+RUN ssh-keygen -A
+RUN adduser -D -s /bin/sh testuser \
+    && echo "testuser:testpass" | chpasswd
+RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    && echo "PermitTunnel yes" >> /etc/ssh/sshd_config \
+    && echo "GatewayPorts yes" >> /etc/ssh/sshd_config \
+    && echo "AllowTcpForwarding yes" >> /etc/ssh/sshd_config
+EXPOSE 22
+CMD ["sh", "-c", "mkdir -p /run/sshd && exec /usr/sbin/sshd -D -e"]

--- a/tests/e2e/Dockerfile.test-runner
+++ b/tests/e2e/Dockerfile.test-runner
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat-openbsd \
     procps \
     sudo \
+    sshpass \
+    sshuttle \
     && rm -rf /var/lib/apt/lists/*
 
 # sing-box

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -96,6 +96,40 @@ def wireguard_port() -> str:
     return _require_env("WIREGUARD_PORT")
 
 
+@pytest.fixture(scope="session")
+def ssh_server() -> str:
+    return _require_env("SSH_SERVER")
+
+
+@pytest.fixture(scope="session")
+def ssh_port() -> str:
+    return _require_env("SSH_PORT")
+
+
+@pytest.fixture(scope="session")
+def ssh_user() -> str:
+    return _require_env("SSH_USER")
+
+
+@pytest.fixture(scope="session")
+def ssh_pass() -> str:
+    return _require_env("SSH_PASS")
+
+
+@pytest.fixture
+def ssh_socks_config(
+    ssh_server: str, ssh_port: str, ssh_user: str, ssh_pass: str
+) -> dict:
+    """SSH SOCKS proxy config for integration tests."""
+    return {
+        "host": ssh_server,
+        "port": ssh_port,
+        "user": ssh_user,
+        "pass": ssh_pass,
+        "socks_port": 11080,
+    }
+
+
 @pytest.fixture
 def real_net() -> NetManager:
     """Real NetManager for the current platform (Linux in K8s)."""
@@ -325,6 +359,7 @@ def _cleanup_after_test():
         "openconnect",
         "sing-box",
         "wireguard-go",
+        "sshpass",
     ):
         subprocess.run(
             ["pkill", "-9", "-f", proc_name], check=False, capture_output=True

--- a/tests/integration/test_sshtunnel.py
+++ b/tests/integration/test_sshtunnel.py
@@ -1,0 +1,149 @@
+"""Integration tests: SSH tunnel SOCKS proxy with real SSH server.
+
+Runs inside test-runner container. SSH server must be running in vpn-e2e network.
+Environment variables provide server address and credentials.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+import pytest
+
+
+pytestmark = pytest.mark.network
+
+
+def _wait_for_port(host: str, port: int, timeout: int = 10) -> bool:
+    """Wait for a TCP port to start listening."""
+    for _ in range(timeout * 2):
+        result = subprocess.run(
+            ["nc", "-z", host, str(port)],
+            capture_output=True,
+            timeout=3,
+        )
+        if result.returncode == 0:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+class TestSSHConnection:
+    """Basic SSH connectivity to the test server."""
+
+    def test_ssh_connection_works(self, ssh_socks_config: dict):
+        """sshpass + ssh can reach the server and run a command."""
+        cfg = ssh_socks_config
+        result = subprocess.run(
+            [
+                "sshpass",
+                "-p",
+                cfg["pass"],
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-p",
+                cfg["port"],
+                f"{cfg['user']}@{cfg['host']}",
+                "echo",
+                "hello",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, f"SSH connection failed: {result.stderr}"
+        assert "hello" in result.stdout
+
+
+class TestSSHSocksProxy:
+    """SOCKS proxy mode: ssh -D creates a local SOCKS5 listener."""
+
+    def test_socks_proxy_creates_tunnel(self, ssh_socks_config: dict):
+        """ssh -D opens SOCKS port and keeps it listening."""
+        cfg = ssh_socks_config
+        socks_port = cfg["socks_port"]
+
+        ssh_proc = subprocess.Popen(
+            [
+                "sshpass",
+                "-p",
+                cfg["pass"],
+                "ssh",
+                "-D",
+                str(socks_port),
+                "-N",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "-p",
+                cfg["port"],
+                f"{cfg['user']}@{cfg['host']}",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        try:
+            assert _wait_for_port("127.0.0.1", socks_port), (
+                f"SOCKS port {socks_port} did not open within timeout"
+            )
+
+            # Verify the port is still listening (not a transient open)
+            check = subprocess.run(
+                ["nc", "-z", "127.0.0.1", str(socks_port)],
+                capture_output=True,
+                timeout=3,
+            )
+            assert check.returncode == 0, "SOCKS port closed unexpectedly"
+
+        finally:
+            ssh_proc.terminate()
+            ssh_proc.wait(timeout=5)
+
+    def test_socks_proxy_disconnect(self, ssh_socks_config: dict):
+        """After killing ssh, SOCKS port stops listening."""
+        cfg = ssh_socks_config
+        socks_port = cfg["socks_port"]
+
+        ssh_proc = subprocess.Popen(
+            [
+                "sshpass",
+                "-p",
+                cfg["pass"],
+                "ssh",
+                "-D",
+                str(socks_port),
+                "-N",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "-p",
+                cfg["port"],
+                f"{cfg['user']}@{cfg['host']}",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        try:
+            assert _wait_for_port("127.0.0.1", socks_port), (
+                f"SOCKS port {socks_port} did not open within timeout"
+            )
+        finally:
+            ssh_proc.terminate()
+            ssh_proc.wait(timeout=5)
+
+        # After kill, port should be closed
+        time.sleep(1)
+        check = subprocess.run(
+            ["nc", "-z", "127.0.0.1", str(socks_port)],
+            capture_output=True,
+            timeout=3,
+        )
+        assert check.returncode != 0, (
+            f"SOCKS port {socks_port} still listening after ssh killed"
+        )

--- a/tests/test_vpn_sshtunnel.py
+++ b/tests/test_vpn_sshtunnel.py
@@ -1,0 +1,411 @@
+"""Tests for SSHTunnelPlugin: SSH tunnel via SOCKS proxy or sshuttle."""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tv.vpn.base import TunnelConfig
+from tv.vpn.sshtunnel import SSHTunnelPlugin
+
+
+@contextlib.contextmanager
+def _socks_connect_ok(plugin, *, socks_port=1080):
+    """Set up successful SOCKS connect: ssh spawns, port opens."""
+    mock_popen = MagicMock()
+    mock_popen.pid = 5555
+    with patch("tv.vpn.sshtunnel.proc") as mock_proc:
+        mock_proc.run_background.return_value = mock_popen
+        mock_proc.is_alive.return_value = True
+        mock_proc.wait_for.return_value = True
+        yield mock_proc
+
+
+@contextlib.contextmanager
+def _socks_connect_fail_port(plugin):
+    """Set up SOCKS connect failure: port never opens."""
+    mock_popen = MagicMock()
+    mock_popen.pid = 5555
+    with patch("tv.vpn.sshtunnel.proc") as mock_proc:
+        mock_proc.run_background.return_value = mock_popen
+        mock_proc.is_alive.return_value = True
+        mock_proc.wait_for.return_value = False
+        yield mock_proc
+
+
+@contextlib.contextmanager
+def _socks_connect_fail_exit(plugin):
+    """Set up SOCKS connect failure: ssh process exits immediately."""
+    mock_popen = MagicMock()
+    mock_popen.pid = 5555
+    with patch("tv.vpn.sshtunnel.proc") as mock_proc:
+        mock_proc.run_background.return_value = mock_popen
+        mock_proc.is_alive.return_value = False
+        mock_proc.wait_for.return_value = False
+        yield mock_proc
+
+
+@contextlib.contextmanager
+def _sshuttle_connect_ok(plugin):
+    """Set up successful sshuttle connect."""
+    mock_popen = MagicMock()
+    mock_popen.pid = 6666
+    with (
+        patch("tv.vpn.sshtunnel.proc") as mock_proc,
+        patch("tv.vpn.sshtunnel.shutil.which", return_value="/usr/bin/sshuttle"),
+    ):
+        mock_proc.run_background.return_value = mock_popen
+        mock_proc.is_alive.return_value = True
+        mock_proc.wait_for.return_value = True
+        yield mock_proc
+
+
+@contextlib.contextmanager
+def _sshuttle_connect_fail_binary(plugin):
+    """Set up sshuttle connect failure: binary not found."""
+    with patch("tv.vpn.sshtunnel.shutil.which", return_value=None):
+        yield
+
+
+@pytest.fixture
+def socks_cfg(tmp_dir) -> TunnelConfig:
+    return TunnelConfig(
+        name="ssh-socks",
+        type="sshtunnel",
+        order=5,
+        log=str(tmp_dir / "sshtunnel.log"),
+        auth={"host": "user@example.com", "port": "22"},
+        extra={"mode": "socks", "socks_port": "1080"},
+    )
+
+
+@pytest.fixture
+def shuttle_cfg(tmp_dir) -> TunnelConfig:
+    return TunnelConfig(
+        name="ssh-shuttle",
+        type="sshtunnel",
+        order=5,
+        log=str(tmp_dir / "sshtunnel.log"),
+        auth={"host": "user@example.com", "port": "22"},
+        extra={"mode": "sshuttle", "subnets": "10.0.0.0/8,192.168.0.0/16"},
+    )
+
+
+@pytest.fixture
+def socks_plugin(socks_cfg, mock_net, logger, tmp_dir):
+    return SSHTunnelPlugin(socks_cfg, mock_net, logger, tmp_dir)
+
+
+@pytest.fixture
+def shuttle_plugin(shuttle_cfg, mock_net, logger, tmp_dir):
+    return SSHTunnelPlugin(shuttle_cfg, mock_net, logger, tmp_dir)
+
+
+# =========================================================================
+# Meta
+# =========================================================================
+
+
+class TestMeta:
+    def test_process_name_socks(self, socks_plugin):
+        assert socks_plugin.process_name == "ssh"
+
+    def test_process_name_sshuttle(self, shuttle_plugin):
+        assert shuttle_plugin.process_name == "sshuttle"
+
+    def test_display_name_socks(self, socks_plugin):
+        assert "socks" in socks_plugin.display_name.lower()
+
+    def test_display_name_sshuttle(self, shuttle_plugin):
+        assert "sshuttle" in shuttle_plugin.display_name.lower()
+
+    def test_registered(self):
+        from tv.vpn.registry import get_plugin
+
+        assert get_plugin("sshtunnel") is SSHTunnelPlugin
+
+    def test_binary(self):
+        assert SSHTunnelPlugin.binary == "ssh"
+
+    def test_type_display_name(self):
+        assert SSHTunnelPlugin.type_display_name == "SSH Tunnel"
+
+    def test_process_names(self):
+        assert "ssh" in SSHTunnelPlugin.process_names
+        assert "sshuttle" in SSHTunnelPlugin.process_names
+
+    def test_config_schema(self):
+        schema = SSHTunnelPlugin.config_schema()
+        keys = [p.key for p in schema]
+        assert "host" in keys
+        assert "mode" in keys
+        assert "port" in keys
+        assert "identity_file" in keys
+        assert "socks_port" in keys
+        assert "subnets" in keys
+
+    def test_config_schema_host_required(self):
+        schema = SSHTunnelPlugin.config_schema()
+        host_param = next(p for p in schema if p.key == "host")
+        assert host_param.required is True
+        assert host_param.env_var == "VPN_SSH_HOST"
+
+
+# =========================================================================
+# SOCKS mode: successful connection
+# =========================================================================
+
+
+class TestConnectSOCKS:
+    def test_normal_connection(self, socks_plugin):
+        """ssh -D spawns, SOCKS port opens."""
+        with _socks_connect_ok(socks_plugin):
+            r = socks_plugin.connect()
+
+        assert r.ok is True
+        assert r.pid == 5555
+        assert "socks5" in r.detail
+
+    def test_builds_correct_command(self, socks_plugin):
+        """Verify ssh command includes -D, -N, ServerAliveInterval."""
+        with _socks_connect_ok(socks_plugin) as mock_proc:
+            socks_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert cmd[0] == "ssh"
+        assert "-D" in cmd
+        assert "1080" in cmd
+        assert "-N" in cmd
+        assert "ServerAliveInterval=30" in " ".join(cmd)
+        assert "user@example.com" in cmd
+
+    def test_custom_socks_port(self, socks_plugin):
+        """Custom SOCKS port used in command."""
+        socks_plugin.cfg.extra["socks_port"] = "9999"
+        with _socks_connect_ok(socks_plugin) as mock_proc:
+            socks_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert "9999" in cmd
+
+    def test_identity_file(self, socks_plugin):
+        """Identity file added to command."""
+        socks_plugin.cfg.extra["identity_file"] = "/home/user/.ssh/id_ed25519"
+        with _socks_connect_ok(socks_plugin) as mock_proc:
+            socks_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert "-i" in cmd
+        assert "/home/user/.ssh/id_ed25519" in cmd
+
+    def test_custom_ssh_port(self, socks_plugin):
+        """Non-default SSH port added to command."""
+        socks_plugin.cfg.auth["port"] = "2222"
+        with _socks_connect_ok(socks_plugin) as mock_proc:
+            socks_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert "-p" in cmd
+        assert "2222" in cmd
+
+    def test_default_port_not_in_cmd(self, socks_plugin):
+        """Default SSH port 22 is not explicitly added to command."""
+        socks_plugin.cfg.auth["port"] = "22"
+        with _socks_connect_ok(socks_plugin) as mock_proc:
+            socks_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert "-p" not in cmd
+
+    def test_no_sudo(self, socks_plugin):
+        """SOCKS mode does not use sudo."""
+        with _socks_connect_ok(socks_plugin) as mock_proc:
+            socks_plugin.connect()
+
+        call_kwargs = mock_proc.run_background.call_args
+        # sudo not passed or False
+        assert call_kwargs[1].get("sudo") is not True
+
+
+# =========================================================================
+# sshuttle mode: successful connection
+# =========================================================================
+
+
+class TestConnectSshuttle:
+    def test_normal_connection(self, shuttle_plugin):
+        """sshuttle spawns and stays alive."""
+        with _sshuttle_connect_ok(shuttle_plugin):
+            r = shuttle_plugin.connect()
+
+        assert r.ok is True
+        assert r.pid == 6666
+        assert "sshuttle" in r.detail
+
+    def test_builds_correct_command(self, shuttle_plugin):
+        """Verify sshuttle command includes -r, subnets, --dns."""
+        with _sshuttle_connect_ok(shuttle_plugin) as mock_proc:
+            shuttle_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert cmd[0] == "sshuttle"
+        assert "-r" in cmd
+        assert "user@example.com" in cmd
+        assert "10.0.0.0/8" in cmd
+        assert "192.168.0.0/16" in cmd
+        assert "--dns" in cmd
+
+    def test_sudo(self, shuttle_plugin):
+        """sshuttle runs with sudo."""
+        with _sshuttle_connect_ok(shuttle_plugin) as mock_proc:
+            shuttle_plugin.connect()
+
+        call_kwargs = mock_proc.run_background.call_args
+        assert call_kwargs[1].get("sudo") is True
+
+    def test_default_subnets(self, shuttle_plugin):
+        """When subnets empty, defaults to 0/0."""
+        shuttle_plugin.cfg.extra["subnets"] = ""
+        with _sshuttle_connect_ok(shuttle_plugin) as mock_proc:
+            shuttle_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert "0/0" in cmd
+
+    def test_custom_ssh_port_in_sshuttle(self, shuttle_plugin):
+        """Non-default SSH port passed via -e to sshuttle."""
+        shuttle_plugin.cfg.auth["port"] = "2222"
+        with _sshuttle_connect_ok(shuttle_plugin) as mock_proc:
+            shuttle_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert "-e" in cmd
+        # Find the -e argument value
+        e_idx = cmd.index("-e")
+        ssh_sub = cmd[e_idx + 1]
+        assert "-p 2222" in ssh_sub
+
+    def test_identity_in_sshuttle(self, shuttle_plugin):
+        """Identity file passed via -e to sshuttle."""
+        shuttle_plugin.cfg.extra["identity_file"] = "/root/.ssh/key"
+        with _sshuttle_connect_ok(shuttle_plugin) as mock_proc:
+            shuttle_plugin.connect()
+
+        cmd = mock_proc.run_background.call_args[0][0]
+        assert "-e" in cmd
+        e_idx = cmd.index("-e")
+        ssh_sub = cmd[e_idx + 1]
+        assert "-i /root/.ssh/key" in ssh_sub
+
+
+# =========================================================================
+# Connection failures
+# =========================================================================
+
+
+class TestConnectFailure:
+    def test_socks_port_not_open(self, socks_plugin, capsys):
+        """SOCKS port never opens - process alive but port closed."""
+        with _socks_connect_fail_port(socks_plugin):
+            r = socks_plugin.connect()
+
+        assert r.ok is False
+
+    def test_socks_process_exits(self, socks_plugin, capsys):
+        """ssh exits immediately."""
+        with _socks_connect_fail_exit(socks_plugin):
+            r = socks_plugin.connect()
+
+        assert r.ok is False
+        out = capsys.readouterr().out
+        assert "ssh" in out.lower() or "SSH" in out
+
+    def test_sshuttle_binary_not_found(self, shuttle_plugin, capsys):
+        """sshuttle not installed."""
+        with _sshuttle_connect_fail_binary(shuttle_plugin):
+            r = shuttle_plugin.connect()
+
+        assert r.ok is False
+        out = capsys.readouterr().out
+        assert "sshuttle" in out.lower() or "not installed" in out.lower()
+
+    def test_no_host_configured(self, socks_plugin, capsys):
+        """Host not set returns failure."""
+        socks_plugin.cfg.auth["host"] = ""
+        with patch("tv.vpn.sshtunnel.proc"):
+            r = socks_plugin.connect()
+
+        assert r.ok is False
+
+
+# =========================================================================
+# Disconnect
+# =========================================================================
+
+
+class TestDisconnect:
+    def test_disconnect_kills_pid(self, socks_plugin):
+        """disconnect() kills process by PID."""
+        socks_plugin._pid = 5555
+        with patch("tv.vpn.base.proc") as mock_base_proc:
+            mock_base_proc.is_alive.return_value = True
+            mock_base_proc.kill_by_pid.return_value = None
+            socks_plugin.disconnect()
+
+        mock_base_proc.kill_by_pid.assert_called_once()
+
+    def test_disconnect_pattern_fallback_socks(self, socks_plugin):
+        """Fallback to pattern kill for SOCKS mode."""
+        socks_plugin._pid = None
+        with patch("tv.vpn.sshtunnel.proc") as mock_proc:
+            mock_proc.is_alive.return_value = False
+            socks_plugin.disconnect()
+
+        mock_proc.kill_pattern.assert_called_once()
+        pattern = mock_proc.kill_pattern.call_args[0][0]
+        assert "ssh -D" in pattern
+        assert "example.com" in pattern
+
+    def test_disconnect_pattern_fallback_sshuttle(self, shuttle_plugin):
+        """Fallback to pattern kill for sshuttle mode."""
+        shuttle_plugin._pid = None
+        with patch("tv.vpn.sshtunnel.proc") as mock_proc:
+            mock_proc.is_alive.return_value = False
+            shuttle_plugin.disconnect()
+
+        mock_proc.kill_pattern.assert_called_once()
+        pattern = mock_proc.kill_pattern.call_args[0][0]
+        assert "sshuttle" in pattern
+        assert "example.com" in pattern
+
+
+# =========================================================================
+# discover_pid
+# =========================================================================
+
+
+class TestDiscoverPid:
+    def test_discover_socks(self, socks_cfg, tmp_dir):
+        """discover_pid finds ssh -D process matching host."""
+        with patch("tv.vpn.sshtunnel.proc") as mock_proc:
+            mock_proc.find_pids.return_value = [4444]
+            pid = SSHTunnelPlugin.discover_pid(socks_cfg, tmp_dir)
+
+        assert pid == 4444
+
+    def test_discover_sshuttle(self, shuttle_cfg, tmp_dir):
+        """discover_pid finds sshuttle process matching host."""
+        with patch("tv.vpn.sshtunnel.proc") as mock_proc:
+            # First call (ssh -D) returns nothing, second (sshuttle) matches
+            mock_proc.find_pids.side_effect = [[], [7777]]
+            pid = SSHTunnelPlugin.discover_pid(shuttle_cfg, tmp_dir)
+
+        assert pid == 7777
+
+    def test_discover_no_host(self, socks_cfg, tmp_dir):
+        """discover_pid returns None when host not set."""
+        socks_cfg.auth = {}
+        pid = SSHTunnelPlugin.discover_pid(socks_cfg, tmp_dir)
+        assert pid is None

--- a/tunnelvault.py
+++ b/tunnelvault.py
@@ -24,7 +24,7 @@ from tv.vpn.base import TunnelConfig
 from tv.vpn.registry import get_plugin
 
 # Ensure all plugins are registered on import
-from tv.vpn import openvpn, fortivpn, openconnect, singbox, wireguard  # noqa: F401
+from tv.vpn import openvpn, fortivpn, openconnect, singbox, wireguard, sshtunnel  # noqa: F401
 
 IS_WINDOWS = platform.system() == "Windows"
 

--- a/tv/app_config.py
+++ b/tv/app_config.py
@@ -22,6 +22,7 @@ class Timeouts:
     openconnect_tun: int = 20
     singbox_iface: int = 15
     wireguard_iface: int = 10
+    sshtunnel_connect: int = 15
     fortivpn_gw_poll: float = 0.5
     fortivpn_gw_attempts: int = 10
     check_subprocess: int = 15
@@ -76,6 +77,8 @@ class Defaults:
     singbox_interface: str = "utun99"
     wireguard_config: str = "wg0.conf"
     network_service: str = "Wi-Fi"
+    sshtunnel_mode: str = "socks"
+    sshtunnel_socks_port: str = "1080"
 
 
 @dataclass

--- a/tv/lang/en.py
+++ b/tv/lang/en.py
@@ -196,6 +196,12 @@ STRINGS: dict[str, str] = {
     "vpn.sb.log_hint": "Log: {path}",
     "vpn.sb.connected": "sing-box connected ({iface})",
     "vpn.sb.config_not_found": "Config file not found: {path}",
+    # --- vpn/sshtunnel.py ---
+    "vpn.ssh.connected_socks": "SSH SOCKS proxy connected (port {port})",
+    "vpn.ssh.connected_sshuttle": "sshuttle connected ({host})",
+    "vpn.ssh.not_connected": "SSH tunnel did not connect within {timeout}s",
+    "vpn.ssh.setup_failed": "SSH tunnel setup failed: {detail}",
+    "vpn.ssh.log_hint": "Check SSH connectivity: ssh -v <host>",
     # --- vpn/wireguard.py ---
     "vpn.wg.connected": "WireGuard connected ({iface})",
     "vpn.wg.not_connected": "WireGuard interface did not appear within {timeout}s",
@@ -213,6 +219,12 @@ STRINGS: dict[str, str] = {
     "param.cert_mode": "Certificate (auto/manual)",
     "param.cert_sha256": "SHA256 certificate",
     "param.fallback_gw": "Fallback GW",
+    "param.ssh_host": "SSH host (user@hostname)",
+    "param.ssh_mode": "SSH mode (socks/sshuttle)",
+    "param.ssh_port": "SSH port",
+    "param.ssh_identity": "SSH key file",
+    "param.ssh_socks_port": "SOCKS port",
+    "param.ssh_subnets": "Subnets (CIDR, comma-separated)",
     # --- daemon.py ---
     "daemon.log_hint": "Log: tail -f {path}",
     "daemon.enabled": "Autostart enabled",

--- a/tv/lang/ru.py
+++ b/tv/lang/ru.py
@@ -196,6 +196,12 @@ STRINGS: dict[str, str] = {
     "vpn.sb.log_hint": "Лог: {path}",
     "vpn.sb.connected": "sing-box подключен ({iface})",
     "vpn.sb.config_not_found": "Файл конфига не найден: {path}",
+    # --- vpn/sshtunnel.py ---
+    "vpn.ssh.connected_socks": "SSH SOCKS прокси подключен (порт {port})",
+    "vpn.ssh.connected_sshuttle": "sshuttle подключен ({host})",
+    "vpn.ssh.not_connected": "SSH туннель не подключился за {timeout}с",
+    "vpn.ssh.setup_failed": "SSH туннель не поднялся: {detail}",
+    "vpn.ssh.log_hint": "Проверьте SSH: ssh -v <host>",
     # --- vpn/wireguard.py ---
     "vpn.wg.connected": "WireGuard подключен ({iface})",
     "vpn.wg.not_connected": "WireGuard интерфейс не появился за {timeout}с",
@@ -213,6 +219,12 @@ STRINGS: dict[str, str] = {
     "param.cert_mode": "Сертификат (auto/manual)",
     "param.cert_sha256": "SHA256 сертификата",
     "param.fallback_gw": "Fallback GW",
+    "param.ssh_host": "SSH хост (user@hostname)",
+    "param.ssh_mode": "SSH режим (socks/sshuttle)",
+    "param.ssh_port": "SSH порт",
+    "param.ssh_identity": "SSH ключ",
+    "param.ssh_socks_port": "SOCKS порт",
+    "param.ssh_subnets": "Подсети (CIDR, через запятую)",
     # --- daemon.py ---
     "daemon.log_hint": "Лог: tail -f {path}",
     "daemon.enabled": "Автозапуск включён",

--- a/tv/vpn/sshtunnel.py
+++ b/tv/vpn/sshtunnel.py
@@ -1,0 +1,293 @@
+"""SSH tunnel connection: SOCKS proxy (-D) or sshuttle mode."""
+
+from __future__ import annotations
+
+import shutil
+import socket
+import time
+from pathlib import Path
+
+from tv import proc, ui
+from tv.app_config import cfg
+from tv.i18n import t
+from tv.vpn.base import ConfigParam, TunnelConfig, TunnelPlugin, VPNResult
+from tv.vpn.registry import register
+
+
+def _port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Check if a TCP port is listening."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+@register("sshtunnel")
+class SSHTunnelPlugin(TunnelPlugin):
+    """SSH tunnel plugin supporting SOCKS proxy and sshuttle modes."""
+
+    binary = "ssh"
+    type_display_name = "SSH Tunnel"
+    process_names = ("ssh", "sshuttle")
+    version_cmd = ("ssh", "-V")
+
+    @classmethod
+    def get_version(cls) -> str:
+        """ssh -V prints to stderr."""
+        if not cls.binary or not shutil.which(cls.binary):
+            return ""
+        import subprocess
+
+        try:
+            r = subprocess.run(
+                cls.version_cmd, capture_output=True, text=True, timeout=5
+            )
+            out = (r.stderr or r.stdout or "").strip()
+            return out.split("\n")[0] if out else ""
+        except Exception:
+            return ""
+
+    @classmethod
+    def config_schema(cls) -> list[ConfigParam]:
+        return [
+            ConfigParam(
+                "host",
+                "param.ssh_host",
+                required=True,
+                env_var="VPN_SSH_HOST",
+                target="auth",
+            ),
+            ConfigParam(
+                "mode",
+                "param.ssh_mode",
+                default=cfg.defaults.sshtunnel_mode,
+                env_var="",
+                target="extra",
+            ),
+            ConfigParam(
+                "port",
+                "param.ssh_port",
+                default=cfg.defaults.sshtunnel_socks_port,
+                env_var="VPN_SSH_PORT",
+                target="auth",
+                prompt=False,
+            ),
+            ConfigParam(
+                "identity_file",
+                "param.ssh_identity",
+                env_var="",
+                target="extra",
+                prompt=False,
+            ),
+            ConfigParam(
+                "socks_port",
+                "param.ssh_socks_port",
+                default=cfg.defaults.sshtunnel_socks_port,
+                env_var="",
+                target="extra",
+                prompt=False,
+            ),
+            ConfigParam(
+                "subnets",
+                "param.ssh_subnets",
+                env_var="",
+                target="extra",
+                prompt=False,
+            ),
+        ]
+
+    @classmethod
+    def emergency_patterns(cls, script_dir: Path) -> list[str]:
+        return ["ssh -D", "sshuttle"]
+
+    @classmethod
+    def discover_pid(cls, tcfg: TunnelConfig, script_dir: Path) -> int | None:
+        host = tcfg.auth.get("host", "")
+        if not host:
+            return None
+        # Try SOCKS mode pattern first
+        pids = proc.find_pids(f"ssh -D.*{host}")
+        if pids:
+            return pids[0]
+        # Try sshuttle pattern
+        pids = proc.find_pids(f"sshuttle.*{host}")
+        if pids:
+            return pids[0]
+        return None
+
+    @property
+    def process_name(self) -> str:
+        mode = self.cfg.extra.get("mode", "socks")
+        return "sshuttle" if mode == "sshuttle" else "ssh"
+
+    @property
+    def display_name(self) -> str:
+        mode = self.cfg.extra.get("mode", "socks")
+        return f"SSH Tunnel ({mode})"
+
+    def _get_mode(self) -> str:
+        return self.cfg.extra.get("mode", "socks")
+
+    def _get_host(self) -> str:
+        return self.cfg.auth.get("host", "")
+
+    def _get_ssh_port(self) -> str:
+        return self.cfg.auth.get("port", "22")
+
+    def _get_socks_port(self) -> int:
+        return int(self.cfg.extra.get("socks_port", "1080"))
+
+    def _get_identity_file(self) -> str:
+        return self.cfg.extra.get("identity_file", "")
+
+    def _get_subnets(self) -> list[str]:
+        raw = self.cfg.extra.get("subnets", "")
+        if not raw:
+            return []
+        return [s.strip() for s in raw.split(",") if s.strip()]
+
+    def connect(self) -> VPNResult:
+        mode = self._get_mode()
+        host = self._get_host()
+
+        if not host:
+            ui.fail(t("vpn.ssh.setup_failed", detail="host not set"))
+            self.log.log("ERROR", "SSH tunnel: host not configured")
+            return VPNResult(ok=False, detail="host not set")
+
+        if mode == "sshuttle":
+            return self._connect_sshuttle(host)
+        return self._connect_socks(host)
+
+    def _connect_socks(self, host: str) -> VPNResult:
+        """SOCKS proxy mode: ssh -D <port> -N."""
+        socks_port = self._get_socks_port()
+        ssh_port = self._get_ssh_port()
+        identity = self._get_identity_file()
+
+        cmd = [
+            "ssh",
+            "-D",
+            str(socks_port),
+            "-N",
+            "-o",
+            "ServerAliveInterval=30",
+            "-o",
+            "ExitOnForwardFailure=yes",
+        ]
+        if identity:
+            cmd.extend(["-i", identity])
+        if ssh_port != "22":
+            cmd.extend(["-p", ssh_port])
+        cmd.append(host)
+
+        self.log.log("INFO", f"Launch: {' '.join(cmd)}")
+
+        ssh_proc = proc.run_background(cmd)
+        pid = ssh_proc.pid
+        self._pid = pid
+
+        # Wait for SOCKS port to become available
+        if not proc.wait_for(
+            f"SSH SOCKS (:{socks_port})",
+            lambda: _port_open("127.0.0.1", socks_port),
+            cfg.timeouts.sshtunnel_connect,
+            self.log,
+            abort_fn=lambda: not proc.is_alive(pid),
+        ):
+            # Check if process died
+            if not proc.is_alive(pid):
+                ui.fail(t("vpn.ssh.setup_failed", detail=f"ssh exited (PID={pid})"))
+                self.log.log("ERROR", f"ssh exited prematurely (PID={pid})")
+            else:
+                ui.fail(
+                    t(
+                        "vpn.ssh.not_connected",
+                        timeout=cfg.timeouts.sshtunnel_connect,
+                    )
+                )
+                self.log.log(
+                    "ERROR",
+                    f"SOCKS port {socks_port} did not open within "
+                    f"{cfg.timeouts.sshtunnel_connect}s",
+                )
+            details: list[tuple[str, str]] = [
+                ("", t("vpn.ssh.log_hint")),
+            ]
+            ui.error_tree(details)
+            return VPNResult(ok=False)
+
+        ui.ok(t("vpn.ssh.connected_socks", port=socks_port))
+        self.log.log("INFO", f"SSH SOCKS connected (PID={pid}, port={socks_port})")
+
+        return VPNResult(ok=True, pid=pid, detail=f"socks5://127.0.0.1:{socks_port}")
+
+    def _connect_sshuttle(self, host: str) -> VPNResult:
+        """sshuttle mode: route subnets through SSH."""
+        if not shutil.which("sshuttle"):
+            ui.fail(t("vpn.ssh.setup_failed", detail="sshuttle not installed"))
+            self.log.log("ERROR", "sshuttle binary not found")
+            return VPNResult(ok=False, detail="sshuttle not found")
+
+        subnets = self._get_subnets()
+        if not subnets:
+            subnets = ["0/0"]
+
+        ssh_port = self._get_ssh_port()
+        identity = self._get_identity_file()
+
+        cmd = ["sshuttle", "-r", host] + subnets + ["--dns"]
+
+        # Build ssh sub-command if non-default port or identity
+        ssh_args: list[str] = []
+        if identity:
+            ssh_args.extend(["-i", identity])
+        if ssh_port != "22":
+            ssh_args.extend(["-p", ssh_port])
+        if ssh_args:
+            cmd.extend(["-e", "ssh " + " ".join(ssh_args)])
+
+        self.log.log("INFO", f"Launch: {' '.join(cmd)}")
+
+        shuttle_proc = proc.run_background(cmd, sudo=True)
+        pid = shuttle_proc.pid
+        self._pid = pid
+
+        # sshuttle takes a moment to set up iptables/pf rules.
+        # Poll for process staying alive as success indicator.
+        if not proc.wait_for(
+            "sshuttle",
+            lambda: proc.is_alive(pid),
+            cfg.timeouts.sshtunnel_connect,
+            self.log,
+        ):
+            ui.fail(t("vpn.ssh.setup_failed", detail="sshuttle did not start"))
+            self.log.log("ERROR", "sshuttle process did not stay alive")
+            return VPNResult(ok=False)
+
+        # Give sshuttle a moment to establish the tunnel
+        time.sleep(1)
+
+        if not proc.is_alive(pid):
+            ui.fail(t("vpn.ssh.setup_failed", detail=f"sshuttle exited (PID={pid})"))
+            self.log.log("ERROR", f"sshuttle exited prematurely (PID={pid})")
+            return VPNResult(ok=False)
+
+        ui.ok(t("vpn.ssh.connected_sshuttle", host=host))
+        self.log.log("INFO", f"sshuttle connected (PID={pid}, host={host})")
+
+        return VPNResult(ok=True, pid=pid, detail=f"sshuttle via {host}")
+
+    def disconnect(self) -> None:
+        """Kill ssh/sshuttle process by PID."""
+        if not self._kill_by_pid():
+            self._kill_by_pattern()
+
+    def _kill_by_pattern(self) -> None:
+        host = self._get_host()
+        mode = self._get_mode()
+        if mode == "sshuttle" and host:
+            proc.kill_pattern(f"sshuttle.*{host}", sudo=True)
+        elif host:
+            proc.kill_pattern(f"ssh -D.*{host}", sudo=True)


### PR DESCRIPTION
## Summary
- SSH tunnel plugin with two modes: SOCKS proxy (`ssh -D`) and sshuttle
- SOCKS: system proxy configuration, port check health
- sshuttle: transparent routing via iptables/pf
- 33 unit tests

Closes #76

## Test plan
- [x] Unit tests pass (33/33)
- [ ] Integration test with SSH server container
- [ ] Manual test both SOCKS and sshuttle modes