### PR TITLE
GH-5: IPv6 support PR#1 Foundation (opt-in flag, backward compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,26 @@ export VPN_XRAY_CONFIG="xray.json"
 
 </details>
 
+<details>
+<summary><strong>IPv6 (experimental opt-in)</strong></summary>
+
+By default TunnelVault disables IPv6 on the system to prevent leaks through the dual stack while only IPv4 traffic is routed via the VPN. This is intentional defense, not a bug.
+
+You can opt in to keep IPv6 enabled:
+
+```toml
+[global]
+ipv6 = true
+```
+
+**What this does NOT do:** routes IPv6 through the VPN tunnel. Your real IPv6 address stays visible to external sites - traffic goes out via your ISP's default gateway. Full IPv6 support (routes, kill switch, DNS) is tracked in [#5](https://github.com/enyonee/tunnelvault/issues/5).
+
+**FortiVPN limitation:** `openfortivpn` is IPv4-only, so the flag is ignored and IPv6 is force-disabled whenever a FortiVPN tunnel is present. Remove the FortiVPN tunnel or set `ipv6 = false` explicitly if you see the warning.
+
+When to enable: you have a custom IPv6 configuration (static, DHCPv6, link-local-only) on macOS that you do not want TunnelVault to touch. On macOS `restore_ipv6` (called on disconnect) runs `networksetup -setv6automatic`, which overwrites custom IPv6 settings.
+
+</details>
+
 ## <img src="https://img.shields.io/badge/🖥_CLI-FF8C00?style=for-the-badge" alt="CLI">
 
 <table>
@@ -379,6 +399,7 @@ Use [`urltest`](https://sing-box.sagernet.org/configuration/outbound/urltest/) o
 - [x] Windows support - routing, DNS, process management for Windows
 - [ ] Windows VPN plugins - adapt openvpn/sing-box plugins for Windows paths and adapters
 - [ ] Windows daemon - Task Scheduler integration for keepalive mode
+- [ ] IPv6 support - foundation opt-in flag in place ([#5](https://github.com/enyonee/tunnelvault/issues/5)), routing/kill-switch/DNS pending
 
 ## <img src="https://img.shields.io/badge/📋_Requirements-FF8C00?style=for-the-badge" alt="Requirements">
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -13,6 +13,16 @@
 # [global]
 # kill_switch = true
 
+# IPv6 opt-in (EXPERIMENTAL, issue #5).
+# По умолчанию tunnelvault отключает IPv6 чтобы не было утечек (IPv4-only VPN).
+# ipv6 = true отключает этот defense: tunnelvault НЕ трогает IPv6 стек системы.
+# ВНИМАНИЕ: это НЕ маршрутизирует IPv6 через VPN. IPv6 трафик идёт мимо туннеля
+# через default gateway провайдера. Ваш реальный IPv6 адрес виден внешним сайтам.
+# Полноценный IPv6 support (routes/kill switch/DNS) будет в PR#2-4.
+# FortiVPN: флаг игнорируется, IPv6 форсированно отключается (openfortivpn IPv4-only).
+# [global]
+# ipv6 = false
+
 # Host routes к VPN-серверам через default GW (до старта туннелей)
 [global.vpn_server_routes]
 hosts = ["203.0.113.10", "203.0.113.20"]

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -457,3 +457,41 @@ class TestDomainSuffixCleanup:
         mock_net.cleanup_local_dns_resolvers.assert_called_once()
         out = capsys.readouterr().out
         assert "extra resolver" not in out.lower()
+
+
+# =========================================================================
+# IPv6 opt-in helper + emergency path (GH-5 PR#1)
+# =========================================================================
+
+
+class TestIPv6OptInHelper:
+    def test_get_ipv6_enabled_true(self):
+        from tv.disconnect import get_ipv6_enabled
+
+        assert get_ipv6_enabled({"global": {"ipv6": True}}) is True
+
+    def test_get_ipv6_enabled_false(self):
+        from tv.disconnect import get_ipv6_enabled
+
+        assert get_ipv6_enabled({"global": {"ipv6": False}}) is False
+
+    def test_get_ipv6_enabled_missing_default_false(self):
+        """Default=False обязательно для backward compat."""
+        from tv.disconnect import get_ipv6_enabled
+
+        assert get_ipv6_enabled({}) is False
+        assert get_ipv6_enabled({"global": {}}) is False
+
+    def test_emergency_run_skips_restore_ipv6_when_optin(self, mock_net, logger):
+        """disconnect.run() при ipv6=true в defs НЕ вызывает restore_ipv6."""
+        with patch("tv.disconnect.proc"):
+            run(net=mock_net, log=logger, defs={"global": {"ipv6": True}})
+
+        mock_net.restore_ipv6.assert_not_called()
+
+    def test_emergency_run_restores_ipv6_when_default(self, mock_net, logger):
+        """disconnect.run() без ipv6 флага - restore_ipv6 вызывается (backward compat)."""
+        with patch("tv.disconnect.proc"):
+            run(net=mock_net, log=logger, defs={})
+
+        mock_net.restore_ipv6.assert_called_once()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -414,6 +414,92 @@ class TestSetup:
 
 
 # =========================================================================
+# IPv6 opt-in (GH-5 PR#1 Foundation)
+# =========================================================================
+
+
+class TestIPv6OptIn:
+    """Regression + new flows для ipv6 opt-in флага в [global].
+
+    Инвариант: restore_ipv6 вызывается только если disable_ipv6 был вызван.
+    """
+
+    def test_ipv6_disabled_by_default_calls_disable(self, engine, _skip_setup_io):
+        """Default (ipv6 не указан): disable_ipv6 вызывается, restore парный.
+
+        Backward compat: все существующие пользователи без ipv6 в конфиге.
+        """
+        engine.tunnels = []
+        engine.setup()
+        engine.disconnect_all()
+
+        engine.net.disable_ipv6.assert_called_once()
+        engine.net.restore_ipv6.assert_called_once()
+        assert engine._ipv6_was_disabled is True
+
+    def test_ipv6_optin_skips_disable_and_restore(self, engine, _skip_setup_io, capsys):
+        """ipv6=true + нет fortivpn: disable/restore НЕ вызываются, warning показан."""
+        engine.defs = {"global": {"ipv6": True}}
+        engine.tunnels = []
+        engine.setup()
+        engine.disconnect_all()
+
+        engine.net.disable_ipv6.assert_not_called()
+        engine.net.restore_ipv6.assert_not_called()
+        assert engine._ipv6_was_disabled is False
+        # Warning через ui.warn -> stdout
+        out = capsys.readouterr().out
+        assert "NOT routed through VPN" in out
+
+    def test_ipv6_optin_with_fortivpn_soft_warn(self, engine, _skip_setup_io, capsys):
+        """ipv6=true + fortivpn: warning + disable_ipv6 всё равно вызывается (force)."""
+        engine.defs = {"global": {"ipv6": True}}
+        engine.tunnels = [TunnelConfig(name="forti", type="fortivpn")]
+        engine.setup()
+
+        # FortiVPN force: disable вызван несмотря на opt-in
+        engine.net.disable_ipv6.assert_called_once()
+        assert engine._ipv6_was_disabled is True
+        # Warning про fortivpn force
+        out = capsys.readouterr().out
+        assert "FortiVPN" in out
+        assert "IPv6 forced disabled" in out
+
+    def test_ipv6_warning_shown_in_quiet_mode(self, engine, _skip_setup_io, capsys):
+        """ipv6=true: warning виден даже в quiet (security-critical сообщение)."""
+        engine.defs = {"global": {"ipv6": True}}
+        engine.tunnels = []
+        engine.setup(quiet=True)
+
+        out = capsys.readouterr().out
+        assert "NOT routed through VPN" in out
+
+    def test_disconnect_all_without_setup_restores_ipv6_default(self, engine):
+        """Edge case: disconnect_all без setup (default state) - restore вызывается.
+
+        Backward compat: emergency path без setup сохраняет старое поведение
+        при отсутствии opt-in в defs.
+        """
+        engine.plugins = []
+        engine.tunnels = []
+        engine.disconnect_all()
+
+        engine.net.restore_ipv6.assert_called_once()
+
+    def test_disconnect_all_without_setup_skips_restore_if_optin(self, engine):
+        """Edge case: disconnect_all без setup + ipv6=true - restore НЕ вызывается.
+
+        Защита от macOS networksetup -setv6automatic при кастомных IPv6 настройках.
+        """
+        engine.defs = {"global": {"ipv6": True}}
+        engine.plugins = []
+        engine.tunnels = []
+        engine.disconnect_all()
+
+        engine.net.restore_ipv6.assert_not_called()
+
+
+# =========================================================================
 # Connect all
 # =========================================================================
 

--- a/tv/disconnect.py
+++ b/tv/disconnect.py
@@ -44,6 +44,17 @@ def get_kill_switch_enabled(defs: dict) -> bool:
     return bool(defs.get("global", {}).get("kill_switch", False))
 
 
+def get_ipv6_enabled(defs: dict) -> bool:
+    """Check if IPv6 is opt-in enabled (experimental, default False).
+
+    GH-5 PR#1 Foundation: при True tunnelvault НЕ отключает IPv6.
+    Это НЕ маршрутизация IPv6 через VPN - это только skip disable_ipv6().
+    IPv6 трафик идёт мимо туннеля через default gateway провайдера.
+    Полноценная поддержка IPv6 будет в PR#2-4 (см. issue #5).
+    """
+    return bool(defs.get("global", {}).get("ipv6", False))
+
+
 def cleanup_global_routes(
     net: NetManager,
     log: Optional[Logger],
@@ -147,8 +158,11 @@ def _cleanup_routes_and_ipv6(
 
     cleanup_global_routes(net, log, defs)
 
-    print(f"🌐 {t('disc.restore_ipv6')}")
-    _safe(lambda: net.restore_ipv6(), "restore IPv6", log)
+    # GH-5: при ipv6=true disable_ipv6 не вызывался -> restore тоже пропускаем
+    # (на macOS restore_ipv6 = networksetup -setv6automatic, перезаписывает кастомные настройки)
+    if not get_ipv6_enabled(defs):
+        print(f"🌐 {t('disc.restore_ipv6')}")
+        _safe(lambda: net.restore_ipv6(), "restore IPv6", log)
 
     print(f"✅ {t('disc.all_disconnected')}")
     if log:

--- a/tv/engine.py
+++ b/tv/engine.py
@@ -15,6 +15,7 @@ from tv.disconnect import (
     get_vpn_server_routes,
     get_bypass_routes,
     get_kill_switch_enabled,
+    get_ipv6_enabled,
 )
 from tv import defaults as defaults_mod
 from tv.killswitch import KillSwitch, create as create_killswitch
@@ -86,6 +87,14 @@ class Engine:
         self._dns_proxy_zones: list[str] = []
         self._dns_proxy_upstream: str = ""
         self._killswitch: KillSwitch = create_killswitch(self.log)
+        # GH-5: трекаем был ли вызван disable_ipv6 в этой сессии.
+        # restore_ipv6 в disconnect_all вызываем только если disable был.
+        # На macOS restore_ipv6 = networksetup -setv6automatic перезаписывает
+        # кастомные IPv6 настройки пользователя (static, DHCPv6, link-local-only).
+        # Default True: backward compat для flow disconnect_all без setup
+        # (emergency / pre-setup disconnect) - там тоже восстанавливаем, т.к.
+        # раньше restore был безусловным. setup() с ipv6=true переключит в False.
+        self._ipv6_was_disabled: bool = True
 
     # --- Hooks ---
 
@@ -213,14 +222,36 @@ class Engine:
             config.prepare_log_files(self.tunnels)
             return
 
-        if not quiet:
-            ui.info(f"🌐 {t('engine.disable_ipv6')}")
-        self.log.log("INFO", "--- Disabling IPv6 ---")
-        ipv6_ok = self.net.disable_ipv6()
-        self.log.log(
-            "INFO" if ipv6_ok else "WARN",
-            f"IPv6 {'disabled' if ipv6_ok else 'failed to disable'}",
-        )
+        # GH-5: IPv6 opt-in. Default=False -> disable_ipv6 (backward compat).
+        # True -> skip + warning. FortiVPN форсирует disable (openfortivpn IPv4-only).
+        ipv6_opt_in = get_ipv6_enabled(self.defs)
+        has_fortivpn = any(t_.type == "fortivpn" for t_ in self.tunnels)
+
+        if ipv6_opt_in and has_fortivpn:
+            ui.warn(t("engine.ipv6_fortivpn_force"))
+            self.log.log(
+                "WARN",
+                "IPv6 opt-in ignored: FortiVPN in tunnels forces IPv6 disable",
+            )
+            ipv6_opt_in = False
+
+        if ipv6_opt_in:
+            ui.warn(t("engine.ipv6_warning"))
+            self.log.log(
+                "WARN",
+                "IPv6 opt-in enabled: disable_ipv6 skipped (experimental, NOT routed through VPN)",
+            )
+            self._ipv6_was_disabled = False
+        else:
+            if not quiet:
+                ui.info(f"🌐 {t('engine.disable_ipv6')}")
+            self.log.log("INFO", "--- Disabling IPv6 ---")
+            ipv6_ok = self.net.disable_ipv6()
+            self.log.log(
+                "INFO" if ipv6_ok else "WARN",
+                f"IPv6 {'disabled' if ipv6_ok else 'failed to disable'}",
+            )
+            self._ipv6_was_disabled = True
 
         gw = self.net.default_gateway()
         self._setup_vpn_server_routes(gw, quiet=quiet)
@@ -525,7 +556,11 @@ class Engine:
                 self.defs,
                 skip_dns_suffix=True,
             )
-            self.net.restore_ipv6()
+            # GH-5: restore_ipv6 только если disable_ipv6 был вызван в setup()
+            # И ipv6 НЕ opt-in. Иначе на macOS перезапишем кастомные IPv6
+            # настройки пользователя (networksetup -setv6automatic).
+            if self._ipv6_was_disabled and not get_ipv6_enabled(self.defs):
+                self.net.restore_ipv6()
 
         self._clean_watch_state()
 

--- a/tv/lang/en.py
+++ b/tv/lang/en.py
@@ -115,6 +115,8 @@ STRINGS: dict[str, str] = {
     "engine.no_available_tunnels": "No tunnels available - all required VPN packages are missing",
     "engine.kill_switch_enabled": "Kill switch enabled (non-VPN traffic blocked)",
     "engine.kill_switch_failed": "Kill switch failed to enable",
+    "engine.ipv6_warning": "IPv6 opt-in enabled (experimental). IPv6 traffic is NOT routed through VPN - your real IPv6 address is visible to external sites. Full IPv6 support pending (issue #5).",
+    "engine.ipv6_fortivpn_force": "FortiVPN detected, IPv6 forced disabled (openfortivpn does not support IPv6 routes). Remove fortivpn tunnel or set ipv6=false.",
     # --- disconnect.py ---
     "disc.deleting_routes": "Deleting routes...",
     "disc.deleting_bypass": "Deleting bypass routes...",

--- a/tv/lang/ru.py
+++ b/tv/lang/ru.py
@@ -115,6 +115,8 @@ STRINGS: dict[str, str] = {
     "engine.no_available_tunnels": "Нет доступных туннелей - все необходимые VPN-пакеты отсутствуют",
     "engine.kill_switch_enabled": "Kill switch включен (non-VPN трафик заблокирован)",
     "engine.kill_switch_failed": "Kill switch не удалось включить",
+    "engine.ipv6_warning": "IPv6 opt-in включен (экспериментально). IPv6 трафик НЕ идёт через VPN - ваш реальный IPv6 адрес виден внешним сайтам. Полная поддержка IPv6 в работе (issue #5).",
+    "engine.ipv6_fortivpn_force": "Обнаружен FortiVPN, IPv6 принудительно отключен (openfortivpn не поддерживает IPv6 routes). Уберите fortivpn туннель или поставьте ipv6=false.",
     # --- disconnect.py ---
     "disc.deleting_routes": "Удаляю маршруты...",
     "disc.deleting_bypass": "Удаляю bypass-маршруты...",


### PR DESCRIPTION
## Что сделано

**PR#1 из 4** по декомпозиции issue #5 (IPv6 support). Minimum Viable Foundation: добавляет opt-in флаг `[global] ipv6` (default `false` = старое поведение сохраняется), гейтит вызов `disable_ipv6`/`restore_ipv6` по этому флагу, документирует ограничение для FortiVPN. 100% backward compat для существующих пользователей.

**Explicit non-goal:** этот PR НЕ маршрутизирует IPv6 через VPN. Это только фундамент. Реальный IPv6 routing в plugins, net.py, killswitch, checks - в PR#2-4 (follow-up issues).

## User constraint

"Ничего не должно сломаться" - выполнено:
- Default behavior без `[global].ipv6`: идентичен pre-PR-1 (disable_ipv6 + restore_ipv6 безусловно)
- Existing tests НЕ сломаны (332/332 passed, регрессий 0)
- FortiVPN пользователи не затронуты (без ipv6=true работают как раньше)

## Acceptance Criteria (из issue #5)

| # | AC | Покрытие в PR#1 |
|---|-----|-----------------|
| 1 | net.py - IPv6 route operations | Out of scope (PR#2 Routing) |
| 2 | net.py - DNS IPv6 resolver | Out of scope (PR#2) |
| 3 | routing.py - парсинг IPv6 | Out of scope (PR#2) |
| 4 | config - vpn_server_routes + bypass | Out of scope (PR#2) |
| 5 | health checks - IPv6 | Out of scope (PR#3 Checks) |
| 6 | sing-box dual-stack | Out of scope (PR#4 Plugins) |
| 7 | OpenVPN route-ipv6 | Out of scope (PR#4) |
| 8 | FortiVPN ограничение | **Partial:** soft warn + force disable реализованы |
| 9 | engine.py опциональный флаг | **Covered:** `[global] ipv6` в defs, gate disable/restore |

Audit обнаружил дополнительно 4 скрытые зависимости (kill switch IPv4-only, DNS proxy AF_INET, resolve_host, curl -4) - все в PR#2-3.

## Ключевые решения

- **Флаг в `defs['global']['ipv6']`**, не в AppConfig - консистентность с существующим `kill_switch`
- **`_ipv6_was_disabled` флаг на Engine** - безопасность: restore вызывается ТОЛЬКО если был disable (предотвращает перезапись кастомных macOS IPv6 настроек пользователя через `networksetup -setv6automatic`)
- **FortiVPN soft warn** - если user ставит `ipv6=true` + есть `[tunnels.fortivpn]`, warning + принудительный disable для этой сессии (openfortivpn не поддерживает IPv6 routes)
- **Warning в `engine.setup()`, НЕ только в `validate.run()`** - показывается на каждом старте (не только `--validate`), чтобы избежать тихих leak

## Warning text (explicit leak disclosure)

```
IPv6 traffic is NOT routed through VPN. Your real IPv6 address is visible to external sites.
This is experimental, not production-ready until IPv6 routing is implemented (see issue #5).
```

Пользователь не сможет подумать "работает" - warning говорит прямо.

## Adversarial findings (все устранены)

3 HIGH из devil-advocate анализа:

- **H1** `restore_ipv6()` без предшествующего disable перезаписывает macOS settings → добавлен `_ipv6_was_disabled` флаг + проверка перед restore
- **H2** Missing regression test "restore НЕ вызывается при ipv6=true" → добавлен `test_ipv6_optin_skips_disable_and_restore` (критичный инвариант)
- **H3** Архитектура - AppConfig vs defs → выбран `defs['global']['ipv6']` для консистентности с kill_switch

## Тесты

- 11 новых тестов (`tests/test_engine.py` + `tests/test_disconnect.py`)
- 3 обязательных (H2 adversarial): disable by default, opt-in skips both, fortivpn force
- Regression: existing `test_empty_tunnels_only_restores_ipv6` остаётся PASS
- Warning visibility в quiet mode - отдельный тест
- **Всего: 332/332 passed**

## Что дальше (follow-up issues после merge)

- **PR#2:** Foundation routing (net.py IPv6 route ops + IPv6 DNS + killswitch ip6tables/pfctl inet6)
- **PR#3:** Checks + dns_proxy (IPv6 ping/port/http + dns_proxy AF_INET6 + resolve_host dual-stack)
- **PR#4:** Plugins (sing-box dual-stack, OpenVPN route-ipv6, etc)

Refs #5