### PR TITLE
GH-83: IPv6 PR#2 Routing + DNS + killswitch (+ existing _is_valid_ip fix)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -27,6 +27,9 @@
 [global.vpn_server_routes]
 hosts = ["203.0.113.10", "203.0.113.20"]
 resolve = ["vpn.example.com"]
+# IPv6 support experimental, требует [global] ipv6 = true.
+# IPv6 адреса можно указывать вместе с IPv4 (разделяются автоматически):
+# hosts = ["203.0.113.10", "2001:db8::1"]
 
 # Bypass - домены/хосты, которые должны идти мимо VPN (через default GW).
 # domain_suffix инжектится в sing-box route rules как outbound "direct",
@@ -34,6 +37,9 @@ resolve = ["vpn.example.com"]
 # [global.bypass]
 # domain_suffix = [".ru", ".su", ".xn--p1ai"]
 # upstream_dns = "77.88.8.8"
+# IPv6 примеры (experimental, требует ipv6 = true):
+# networks = ["2001:db8::/32", "fe80::/10"]
+# hosts = ["2001:db8::1"]
 
 # === Туннели ===
 
@@ -126,6 +132,9 @@ log = "/tmp/sing-box.log"
 [tunnels.singbox.routes]
 hosts = ["203.0.113.30"]
 networks = ["172.18.0.0/16"]
+# IPv6 (experimental - требует [global] ipv6 = true):
+# networks = ["172.18.0.0/16", "2001:db8:1::/48"]
+# hosts = ["203.0.113.30", "2001:db8::dead:beef"]
 
 [tunnels.singbox.checks]
 ports = [{ host = "203.0.113.30", port = 443 }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,13 @@ def mock_net() -> MagicMock:
     net.restore_ipv6.return_value = True
     net.delete_host_route.return_value = True
     net.delete_net_route.return_value = True
+    # IPv6 primitives (PR#2)
+    net.add_host_route6.return_value = True
+    net.add_net_route6.return_value = True
+    net.add_iface_route6.return_value = True
+    net.delete_host_route6.return_value = True
+    net.delete_net_route6.return_value = True
+    net.set_dns6.return_value = {"alpha.local": True}
     net.route_table.return_value = "default via 192.168.1.1 dev en0"
     net.iface_info.return_value = ""
     net.ppp_peer.return_value = ""

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -497,7 +497,8 @@ class TestLinuxKillSwitch:
         ks._active = True
         ks.disable()
         ip6_x = [
-            c for c in mock_run.call_args_list
+            c
+            for c in mock_run.call_args_list
             if c.args[0][:2] == ["sudo", "ip6tables"] and "-X" in c.args[0]
         ]
         assert len(ip6_x) == 2

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -15,11 +15,17 @@ from tv.killswitch import (
     _IPTABLES_CHAIN_IN,
     _WIN_RULE_PREFIX,
     _is_valid_ip,
+    _is_valid_ipv4,
+    _is_valid_ipv6,
     _is_valid_network,
+    _is_valid_ipv4_network,
+    _is_valid_ipv6_network,
     _is_valid_iface,
     _sanitize_ips,
     _sanitize_networks,
     _sanitize_ifaces,
+    _split_by_family,
+    _split_networks_by_family,
     create,
 )
 
@@ -75,6 +81,75 @@ class TestSanitization:
     def test_sanitize_ifaces_filters(self):
         result = _sanitize_ifaces(["utun99", "bad iface", "tun0"])
         assert result == ["utun99", "tun0"]
+
+    # ---- IPv6 support (pre-existing regression fix + new helpers) ----
+
+    def test_is_valid_ip_accepts_ipv4_and_ipv6(self):
+        """_is_valid_ip принимает IPv4 И IPv6. Фикс критичного бага:
+        при IPv6 VPN server адресе _sanitize_ips выкидывал его, killswitch
+        блокировал VPN handshake."""
+        assert _is_valid_ip("1.2.3.4")
+        assert _is_valid_ip("2001:db8::1")
+        assert _is_valid_ip("fe80::1")
+        assert _is_valid_ip("::1")
+        assert _is_valid_ip("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+        # Не принимает CIDR и мусор
+        assert not _is_valid_ip("2001:db8::/32")
+        assert not _is_valid_ip("1.2.3.4/32")
+        assert not _is_valid_ip("not-an-ip")
+        assert not _is_valid_ip("")
+
+    def test_is_valid_ipv4_strict(self):
+        assert _is_valid_ipv4("1.2.3.4")
+        assert not _is_valid_ipv4("2001:db8::1")
+        assert not _is_valid_ipv4("::1")
+
+    def test_is_valid_ipv6_strict(self):
+        assert _is_valid_ipv6("2001:db8::1")
+        assert _is_valid_ipv6("::1")
+        assert _is_valid_ipv6("fe80::1")
+        assert not _is_valid_ipv6("1.2.3.4")
+
+    def test_is_valid_network_accepts_ipv4_and_ipv6(self):
+        assert _is_valid_network("10.0.0.0/8")
+        assert _is_valid_network("2001:db8::/32")
+        assert _is_valid_network("fe80::/10")
+        assert _is_valid_network("::/0")
+        assert not _is_valid_network("not-a-net")
+
+    def test_is_valid_ipv4_network_strict(self):
+        assert _is_valid_ipv4_network("10.0.0.0/8")
+        assert not _is_valid_ipv4_network("2001:db8::/32")
+
+    def test_is_valid_ipv6_network_strict(self):
+        assert _is_valid_ipv6_network("2001:db8::/32")
+        assert _is_valid_ipv6_network("::/0")
+        assert not _is_valid_ipv6_network("10.0.0.0/8")
+
+    def test_sanitize_ips_accepts_ipv6(self):
+        """После фикса IPv6 VPN server IP больше не выкидывается."""
+        result = _sanitize_ips(["1.2.3.4", "2001:db8::1", "bad"])
+        assert result == ["1.2.3.4", "2001:db8::1"]
+
+    def test_sanitize_networks_accepts_ipv6(self):
+        result = _sanitize_networks(["10.0.0.0/8", "2001:db8::/32", "bad"])
+        assert result == ["10.0.0.0/8", "2001:db8::/32"]
+
+    def test_split_by_family(self):
+        v4, v6 = _split_by_family(["1.2.3.4", "2001:db8::1", "5.6.7.8", "::1"])
+        assert v4 == ["1.2.3.4", "5.6.7.8"]
+        assert v6 == ["2001:db8::1", "::1"]
+
+    def test_split_by_family_empty(self):
+        v4, v6 = _split_by_family([])
+        assert v4 == [] and v6 == []
+
+    def test_split_networks_by_family(self):
+        v4, v6 = _split_networks_by_family(
+            ["10.0.0.0/8", "2001:db8::/32", "192.168.0.0/16", "fe80::/10"]
+        )
+        assert v4 == ["10.0.0.0/8", "192.168.0.0/16"]
+        assert v6 == ["2001:db8::/32", "fe80::/10"]
 
 
 # =========================================================================

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -461,8 +461,13 @@ class TestLinuxKillSwitch:
         ]
         assert len(lo_calls) >= 1
 
+    @patch("tv.killswitch.shutil.which", return_value=None)
     @patch("tv.killswitch._run")
-    def test_disable_removes_chain(self, mock_run):
+    def test_disable_removes_chain(self, mock_run, mock_which):
+        """Без ip6tables (which=None): только IPv4 chain cleanup.
+
+        С ip6tables (реальная Linux) также чистится ip6tables - это покрыто
+        test_disable_also_cleans_ip6tables_if_available."""
         mock_run.return_value = MagicMock(returncode=0, stderr="")
         ks = LinuxKillSwitch()
         ks._active = True
@@ -472,14 +477,30 @@ class TestLinuxKillSwitch:
         assert ok
         assert not ks.active
 
-        # Verify both chains deleted
+        # Только IPv4 iptables -X вызовы (ip6tables skipped т.к. which=None)
         delete_calls = [
             c
             for c in mock_run.call_args_list
-            if "-X" in c.args[0]
+            if c.args[0][:2] == ["sudo", "iptables"]
+            and "-X" in c.args[0]
             and (_IPTABLES_CHAIN in c.args[0] or _IPTABLES_CHAIN_IN in c.args[0])
         ]
         assert len(delete_calls) == 2
+
+    @patch("tv.killswitch.shutil.which", return_value="/usr/sbin/ip6tables")
+    @patch("tv.killswitch._run")
+    def test_disable_also_cleans_ip6tables_if_available(self, mock_run, mock_which):
+        """disable() всегда чистит ip6tables если утилита доступна - избегаем
+        dangling rules если раньше был enable(ipv6_enabled=True)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+        ks._active = True
+        ks.disable()
+        ip6_x = [
+            c for c in mock_run.call_args_list
+            if c.args[0][:2] == ["sudo", "ip6tables"] and "-X" in c.args[0]
+        ]
+        assert len(ip6_x) == 2
 
     @patch("tv.killswitch.shutil.which", return_value="/usr/sbin/ip6tables")
     @patch("tv.killswitch._run")

--- a/tests/test_killswitch.py
+++ b/tests/test_killswitch.py
@@ -217,6 +217,67 @@ class TestBuildPfRules:
         assert "block out inet all" in rules
         assert "block in inet all" in rules
 
+    # ---- IPv6 rules (PR#2, only when ipv6_enabled=True) ----
+
+    def test_ipv6_disabled_by_default(self):
+        """Backward compat: ipv6_enabled=False (default) - нет inet6 rules."""
+        rules = _build_pf_rules(
+            vpn_interfaces=["utun99"],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        assert "inet6" not in rules
+        assert "block out inet6" not in rules
+
+    def test_ipv6_enabled_adds_block(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=["utun99"],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=True,
+        )
+        assert "block out inet6 all" in rules
+        assert "block in inet6 all" in rules
+
+    def test_ipv6_enabled_allow_server(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=["utun99"],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=True,
+            vpn_server_ips6=["2001:db8::1"],
+        )
+        assert "pass out quick inet6 proto { tcp, udp } to 2001:db8::1" in rules
+        assert "pass in quick inet6 proto { tcp, udp } from 2001:db8::1" in rules
+
+    def test_ipv6_enabled_allow_bypass_net(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=[],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=True,
+            bypass_networks6=["2001:db8::/32"],
+        )
+        assert "pass out quick inet6 to 2001:db8::/32" in rules
+
+    def test_ipv6_dhcpv6_and_loopback_dns(self):
+        rules = _build_pf_rules(
+            vpn_interfaces=[],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=True,
+        )
+        # DHCPv6 ports 546/547
+        assert "port 546 to any port 547" in rules
+        assert "port 547 to any port 546" in rules
+        # IPv6 loopback DNS
+        assert "to ::1 port 53" in rules
+
 
 # =========================================================================
 # Darwin (pf) kill switch
@@ -253,6 +314,63 @@ class TestDarwinKillSwitch:
             if any("pfctl" in str(a) for a in c.args[0])
         ]
         assert len(pfctl_calls) >= 1
+
+    @patch("tv.killswitch._run")
+    def test_enable_ipv6_kwarg_passes_through(self, mock_run):
+        """ipv6_enabled=True раздельные inet/inet6 rules в pfctl ruleset."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = DarwinKillSwitch()
+
+        pf_content = "# Default pf.conf\n"
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            mock_open.return_value.read = MagicMock(return_value=pf_content)
+            mock_open.return_value.readlines = MagicMock(return_value=[pf_content])
+
+            ok = ks.enable(
+                vpn_interfaces=["utun99"],
+                vpn_server_ips=["1.2.3.4", "2001:db8::1"],
+                bypass_ips=[],
+                bypass_networks=["10.0.0.0/8", "2001:db8::/32"],
+                ipv6_enabled=True,
+            )
+        assert ok
+        # Проверим что pfctl -f stdin получил и inet и inet6 rules
+        stdin_input = None
+        for c in mock_run.call_args_list:
+            if c.kwargs.get("input") and "pfctl" in str(c.args[0]):
+                stdin_input = c.kwargs["input"]
+                break
+        assert stdin_input is not None
+        assert "to 1.2.3.4" in stdin_input  # IPv4 server
+        assert "to 2001:db8::1" in stdin_input  # IPv6 server
+        assert "block out inet6 all" in stdin_input
+
+    @patch("tv.killswitch._run")
+    def test_enable_ipv6_default_false(self, mock_run):
+        """Default ipv6_enabled=False - нет IPv6 rules (backward compat)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = DarwinKillSwitch()
+        pf_content = "# Default pf.conf\n"
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            mock_open.return_value.read = MagicMock(return_value=pf_content)
+            mock_open.return_value.readlines = MagicMock(return_value=[pf_content])
+
+            ks.enable(
+                vpn_interfaces=["utun99"],
+                vpn_server_ips=["1.2.3.4"],
+                bypass_ips=[],
+                bypass_networks=[],
+            )
+        stdin_input = next(
+            c.kwargs["input"]
+            for c in mock_run.call_args_list
+            if c.kwargs.get("input") and "pfctl" in str(c.args[0])
+        )
+        assert "inet6" not in stdin_input
 
     @patch("tv.killswitch._run")
     def test_disable_flushes_anchor(self, mock_run):
@@ -363,6 +481,86 @@ class TestLinuxKillSwitch:
         ]
         assert len(delete_calls) == 2
 
+    @patch("tv.killswitch.shutil.which", return_value="/usr/sbin/ip6tables")
+    @patch("tv.killswitch._run")
+    def test_enable_ipv6_creates_ip6tables_chain(self, mock_run, mock_which):
+        """ipv6_enabled=True + ip6tables доступен -> ip6tables chains."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+
+        ok = ks.enable(
+            vpn_interfaces=["tun0"],
+            vpn_server_ips=["1.2.3.4", "2001:db8::1"],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=True,
+        )
+        assert ok
+
+        # Проверим что ip6tables -N (создание chain) вызван
+        ip6_create = [
+            c
+            for c in mock_run.call_args_list
+            if "ip6tables" in c.args[0] and "-N" in c.args[0]
+        ]
+        assert len(ip6_create) == 2  # OUTPUT + INPUT chains
+
+        # Проверим что IPv6 server IP попал в ip6tables allow
+        ip6_server = [
+            c
+            for c in mock_run.call_args_list
+            if "ip6tables" in c.args[0]
+            and "2001:db8::1" in c.args[0]
+            and "ACCEPT" in c.args[0]
+        ]
+        assert len(ip6_server) >= 1
+
+        # IPv4 server НЕ должен попадать в ip6tables
+        ip6_v4 = [
+            c
+            for c in mock_run.call_args_list
+            if "ip6tables" in c.args[0] and "1.2.3.4" in c.args[0]
+        ]
+        assert len(ip6_v4) == 0
+
+    @patch("tv.killswitch.ui")
+    @patch("tv.killswitch.shutil.which", return_value=None)
+    @patch("tv.killswitch._run")
+    def test_enable_ipv6_missing_ip6tables_warns(self, mock_run, mock_which, mock_ui):
+        """M6: ip6tables отсутствует + ipv6_enabled=True -> visible ui.warn."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+
+        ok = ks.enable(
+            vpn_interfaces=["tun0"],
+            vpn_server_ips=[],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=True,
+        )
+        assert ok  # IPv4 killswitch всё равно работает
+        # ui.warn вызван с сообщением про ip6tables
+        assert mock_ui.warn.called
+        warn_arg = mock_ui.warn.call_args[0][0]
+        assert "ip6tables missing" in warn_arg
+
+    @patch("tv.killswitch.shutil.which", return_value=None)
+    @patch("tv.killswitch._run")
+    def test_enable_ipv6_false_no_ip6tables_calls(self, mock_run, mock_which):
+        """ipv6_enabled=False (default) - нет ip6tables calls даже если which вернёт что-то."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+        ks.enable(
+            vpn_interfaces=["tun0"],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        ip6_calls = [c for c in mock_run.call_args_list if "ip6tables" in c.args[0]]
+        # Может быть только disable() flush - но в enable flow никаких ip6tables
+        # (mock_which return_value=None, не dostapan)
+        assert len(ip6_calls) == 0
+
     @patch("tv.killswitch._run")
     def test_enable_cleans_previous_first(self, mock_run):
         """Enable should flush any existing chain before creating new one."""
@@ -433,10 +631,122 @@ class TestWindowsKillSwitch:
         delete_calls = [c for c in mock_run.call_args_list if "delete" in c.args[0]]
         assert len(delete_calls) >= 2  # BlockAll + at least AllowLoopback
 
+    @patch("tv.killswitch._run")
+    def test_enable_loopback6_always_allowed(self, mock_run):
+        """M9: ::1/128 всегда разрешён независимо от ipv6_enabled."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = WindowsKillSwitch()
+        ks.enable(
+            vpn_interfaces=[],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=False,
+        )
+        loopback6 = [
+            c for c in mock_run.call_args_list if "remoteip=::1/128" in c.args[0]
+        ]
+        assert len(loopback6) == 2  # out + in
+
+    @patch("tv.killswitch._run")
+    def test_enable_ipv6_vpn_server(self, mock_run):
+        """ipv6_enabled=True + IPv6 VPN server -> AllowVPNServers6 rule."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = WindowsKillSwitch()
+        ks.enable(
+            vpn_interfaces=[],
+            vpn_server_ips=["1.2.3.4", "2001:db8::1"],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=True,
+        )
+        v6_rules = [
+            c for c in mock_run.call_args_list if "remoteip=2001:db8::1" in c.args[0]
+        ]
+        assert len(v6_rules) >= 1
+        # IPv4 server отдельно
+        v4_rules = [
+            c for c in mock_run.call_args_list if "remoteip=1.2.3.4" in c.args[0]
+        ]
+        assert len(v4_rules) >= 1
+
+    @patch("tv.killswitch._run")
+    def test_enable_ipv6_disabled_no_vpn6_rules(self, mock_run):
+        """ipv6_enabled=False - нет ADD AllowVPNServers6 (delete допустим для idempotent cleanup)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = WindowsKillSwitch()
+        ks.enable(
+            vpn_interfaces=[],
+            vpn_server_ips=["1.2.3.4", "2001:db8::1"],
+            bypass_ips=[],
+            bypass_networks=[],
+            ipv6_enabled=False,
+        )
+        # Фильтруем только add rule (не delete - тот часть idempotent cleanup)
+        v6_server_add = [
+            c
+            for c in mock_run.call_args_list
+            if "AllowVPNServers6" in str(c.args[0]) and "add" in c.args[0]
+        ]
+        assert len(v6_server_add) == 0
+
+    @patch("tv.killswitch._run")
+    def test_disable_removes_ipv6_rules(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = WindowsKillSwitch()
+        ks._active = True
+        ks.disable()
+        # Проверим что IPv6 suffix-правила перечислены в delete
+        all_delete_names = [
+            str(c.args[0]) for c in mock_run.call_args_list if "delete" in c.args[0]
+        ]
+        joined = " ".join(all_delete_names)
+        assert "AllowLoopback6" in joined
+        assert "AllowVPNServers6" in joined
+
 
 # =========================================================================
 # Factory
 # =========================================================================
+
+
+class TestBackwardCompat:
+    """AC8 invariant: все существующие вызовы enable() БЕЗ ipv6_enabled
+    работают идентично pre-PR. ipv6_enabled default False - нет IPv6 rules."""
+
+    @patch("tv.killswitch._run")
+    def test_linux_enable_no_ipv6_kwarg_works(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = LinuxKillSwitch()
+        ok = ks.enable(
+            vpn_interfaces=["tun0"],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        assert ok
+        # Нет ip6tables calls
+        ip6_calls = [c for c in mock_run.call_args_list if "ip6tables" in c.args[0]]
+        assert len(ip6_calls) == 0
+
+    @patch("tv.killswitch._run")
+    def test_windows_enable_no_ipv6_kwarg_works(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        ks = WindowsKillSwitch()
+        ok = ks.enable(
+            vpn_interfaces=[],
+            vpn_server_ips=["1.2.3.4"],
+            bypass_ips=[],
+            bypass_networks=[],
+        )
+        assert ok
+        # Только ADD AllowVPNServers6 не должно быть (delete - idempotent cleanup)
+        v6_server_add = [
+            c
+            for c in mock_run.call_args_list
+            if "AllowVPNServers6" in str(c.args[0]) and "add" in c.args[0]
+        ]
+        assert len(v6_server_add) == 0
 
 
 class TestFactory:

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -588,3 +588,273 @@ class TestLinuxNetInverse:
             subprocess.CompletedProcess([], 1, "", ""),
         ]
         assert linux_net.ppp_peer("ppp0") == ""
+
+
+# =========================================================================
+# IPv6 primitives (PR#2)
+# =========================================================================
+
+
+class TestDarwinIPv6:
+    """macOS IPv6 routes: 'route add -inet6 <target> -interface <iface>'.
+
+    ВАЖНО: add_iface_route6 НЕ использует ppp_peer (IPv4-only) - сразу
+    -interface utunN прямо. macOS ядро находит next-hop через интерфейс.
+    """
+
+    @patch("subprocess.run")
+    def test_add_host_route6(self, mock_run, darwin_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = darwin_net.add_host_route6("2001:db8::1", "fe80::1")
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert args == [
+            "sudo",
+            "route",
+            "add",
+            "-inet6",
+            "-host",
+            "2001:db8::1",
+            "fe80::1",
+        ]
+
+    @patch("subprocess.run")
+    def test_add_net_route6(self, mock_run, darwin_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = darwin_net.add_net_route6("2001:db8::/32", "fe80::1")
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert "-inet6" in args and "-net" in args and "2001:db8::/32" in args
+
+    @patch("subprocess.run")
+    def test_add_iface_route6_tun_uses_interface_flag(self, mock_run, darwin_net):
+        """IPv6 на utun* идёт через -interface (НЕ ppp_peer, который IPv4-only)."""
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = darwin_net.add_iface_route6("2001:db8::/32", "utun99", host=False)
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert args == [
+            "sudo",
+            "route",
+            "add",
+            "-inet6",
+            "-net",
+            "2001:db8::/32",
+            "-interface",
+            "utun99",
+        ]
+
+    @patch("subprocess.run")
+    def test_add_iface_route6_host(self, mock_run, darwin_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        darwin_net.add_iface_route6("2001:db8::1", "utun99", host=True)
+        args = mock_run.call_args[0][0]
+        assert "-host" in args and "2001:db8::1" in args
+
+    @patch("subprocess.run")
+    def test_delete_host_route6(self, mock_run, darwin_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = darwin_net.delete_host_route6("2001:db8::1")
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert args == ["sudo", "route", "delete", "-inet6", "-host", "2001:db8::1"]
+
+    @patch("subprocess.run")
+    def test_delete_net_route6(self, mock_run, darwin_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        darwin_net.delete_net_route6("2001:db8::/32")
+        args = mock_run.call_args[0][0]
+        assert args == ["sudo", "route", "delete", "-inet6", "-net", "2001:db8::/32"]
+
+    @patch("subprocess.run")
+    def test_set_dns6_writes_resolver_file(self, mock_run, darwin_net):
+        """IPv6 nameserver без скобок: 'nameserver 2001:db8::1'."""
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        results = darwin_net.set_dns6(["test.local"], ["2001:db8::1"])
+        assert results["test.local"] is True
+        # Проверим что tee получил правильный content (IPv6 без brackets)
+        tee_call = next(c for c in mock_run.call_args_list if "tee" in c[0][0])
+        content = tee_call.kwargs.get("input", "")
+        assert "nameserver 2001:db8::1" in content
+        assert "[" not in content  # без скобок
+
+    @patch("subprocess.run")
+    def test_set_dns6_empty_nameservers_noop(self, mock_run, darwin_net):
+        """Пустой nameservers - no-op, нет subprocess calls (защита M7)."""
+        results = darwin_net.set_dns6(["test.local"], [])
+        assert results == {"test.local": False}
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_set_dns6_empty_domains_noop(self, mock_run, darwin_net):
+        results = darwin_net.set_dns6([], ["2001:db8::1"])
+        assert results == {}
+
+
+class TestLinuxIPv6:
+    """Linux IPv6: 'ip -6 route replace' (не add - безопаснее при существующем ::/0 от RA)."""
+
+    @patch("subprocess.run")
+    def test_add_host_route6_via_ip6_replace(self, mock_run, linux_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = linux_net.add_host_route6("2001:db8::1", "fe80::1")
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert args == [
+            "sudo",
+            "ip",
+            "-6",
+            "route",
+            "replace",
+            "2001:db8::1/128",
+            "via",
+            "fe80::1",
+        ]
+
+    @patch("subprocess.run")
+    def test_add_net_route6_replace(self, mock_run, linux_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        linux_net.add_net_route6("2001:db8::/32", "fe80::1")
+        args = mock_run.call_args[0][0]
+        assert "replace" in args and "2001:db8::/32" in args
+        assert "via" in args and "fe80::1" in args
+
+    @patch("subprocess.run")
+    def test_add_iface_route6_dev(self, mock_run, linux_net):
+        """ip -6 route replace <cidr> dev <iface> - обходит RA-conflict."""
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        linux_net.add_iface_route6("2001:db8::/32", "tun0", host=False)
+        args = mock_run.call_args[0][0]
+        assert args == [
+            "sudo",
+            "ip",
+            "-6",
+            "route",
+            "replace",
+            "2001:db8::/32",
+            "dev",
+            "tun0",
+        ]
+
+    @patch("subprocess.run")
+    def test_add_iface_route6_host_uses_128(self, mock_run, linux_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        linux_net.add_iface_route6("2001:db8::1", "tun0", host=True)
+        args = mock_run.call_args[0][0]
+        assert "2001:db8::1/128" in args
+
+    @patch("subprocess.run")
+    def test_delete_host_route6_uses_128(self, mock_run, linux_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        linux_net.delete_host_route6("2001:db8::1")
+        args = mock_run.call_args[0][0]
+        assert args == ["sudo", "ip", "-6", "route", "del", "2001:db8::1/128"]
+
+    @patch("subprocess.run")
+    def test_delete_net_route6(self, mock_run, linux_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        linux_net.delete_net_route6("2001:db8::/32")
+        args = mock_run.call_args[0][0]
+        assert args == ["sudo", "ip", "-6", "route", "del", "2001:db8::/32"]
+
+    @patch("tv.net.shutil.which", return_value="/usr/bin/resolvectl")
+    @patch("subprocess.run")
+    def test_set_dns6_resolvectl(self, mock_run, mock_which, linux_net):
+        """resolvectl принимает IPv6 nameservers без кавычек."""
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        results = linux_net.set_dns6(["test.local"], ["2001:db8::1"], "tun0")
+        assert results["test.local"] is True
+        # Проверим что resolvectl dns tun0 2001:db8::1 (без кавычек)
+        dns_call = next(
+            c
+            for c in mock_run.call_args_list
+            if "resolvectl" in c[0][0] and "dns" in c[0][0]
+        )
+        args = dns_call[0][0]
+        assert "2001:db8::1" in args
+        # Без quoting - IPv6 адрес прямо как аргумент
+        assert "'2001:db8::1'" not in args
+
+    @patch("subprocess.run")
+    def test_set_dns6_empty_nameservers_noop(self, mock_run, linux_net):
+        """Защита M7: пустой nameservers - no-op (иначе resolvectl СБРАСЫВАЕТ DNS)."""
+        results = linux_net.set_dns6(["test.local"], [], "tun0")
+        assert results == {"test.local": False}
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_set_dns6_no_interface_noop(self, mock_run, linux_net):
+        results = linux_net.set_dns6(["test.local"], ["2001:db8::1"], "")
+        assert results == {"test.local": False}
+        mock_run.assert_not_called()
+
+    @patch("tv.net.shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_set_dns6_no_resolvectl_noop(self, mock_run, mock_which, linux_net):
+        results = linux_net.set_dns6(["test.local"], ["2001:db8::1"], "tun0")
+        assert results == {"test.local": False}
+        mock_run.assert_not_called()
+
+
+class TestIPv6Defaults:
+    """NetManager ABC: defaults для IPv6 методов - backward compat для stub реализаций."""
+
+    def test_add_host_route6_default_false(self):
+        """Базовый класс: add_host_route6 возвращает False (no-op)."""
+        # Используем DarwinNet, но вызовем через super(), чтобы проверить ABC default.
+        # Проще: создадим mock класс на базе NetManager без переопределения IPv6.
+        from tv.net import NetManager
+
+        class MinimalNet(NetManager):
+            def default_gateway(self):
+                return None
+
+            def interfaces(self):
+                return {}
+
+            def check_interface(self, name):
+                return False
+
+            def add_host_route(self, ip, gateway):
+                return False
+
+            def add_net_route(self, net, gateway):
+                return False
+
+            def add_iface_route(self, target, iface, host=True):
+                return False
+
+            def setup_dns_resolver(self, domains, nameservers, interface=""):
+                return {}
+
+            def cleanup_dns_resolver(self, domains, interface=""):
+                return None
+
+            def disable_ipv6(self):
+                return False
+
+            def restore_ipv6(self):
+                return False
+
+            def delete_host_route(self, ip):
+                return False
+
+            def delete_net_route(self, net):
+                return False
+
+            def route_table(self, lines=None):
+                return ""
+
+            def iface_info(self, name):
+                return ""
+
+            def ppp_peer(self, name):
+                return ""
+
+        n = MinimalNet()
+        assert n.add_host_route6("2001:db8::1", "fe80::1") is False
+        assert n.add_net_route6("2001:db8::/32", "fe80::1") is False
+        assert n.add_iface_route6("2001:db8::/32", "tun0") is False
+        assert n.delete_host_route6("2001:db8::1") is False
+        assert n.delete_net_route6("2001:db8::/32") is False
+        assert n.set_dns6(["test.local"], ["2001:db8::1"]) == {"test.local": False}

--- a/tests/test_net_windows.py
+++ b/tests/test_net_windows.py
@@ -372,3 +372,83 @@ class TestResolveHostFallbacks:
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("Name not found")):
             ips = win_net.resolve_host("nonexistent.test")
         assert ips == []
+
+
+# =========================================================================
+# WindowsNet IPv6 primitives (PR#2)
+# =========================================================================
+
+
+class TestWindowsIPv6:
+    """Windows IPv6 routes: 'netsh interface ipv6 add route <cidr> nexthop=<gw>'."""
+
+    @patch("subprocess.run")
+    def test_add_host_route6(self, mock_run, win_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = win_net.add_host_route6("2001:db8::1", "fe80::1")
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert args[:5] == ["netsh", "interface", "ipv6", "add", "route"]
+        assert "2001:db8::1/128" in args
+        assert "nexthop=fe80::1" in args
+
+    @patch("subprocess.run")
+    def test_add_net_route6(self, mock_run, win_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = win_net.add_net_route6("2001:db8::/32", "fe80::1")
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert "2001:db8::/32" in args
+        assert "nexthop=fe80::1" in args
+
+    @patch("subprocess.run")
+    def test_add_net_route6_invalid_no_slash(self, mock_run, win_net):
+        """network без CIDR - False, нет subprocess call."""
+        ok = win_net.add_net_route6("2001:db8::1", "fe80::1")
+        assert ok is False
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_add_iface_route6(self, mock_run, win_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = win_net.add_iface_route6("2001:db8::/32", "VPN Adapter", host=False)
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert args[:5] == ["netsh", "interface", "ipv6", "add", "route"]
+        assert "2001:db8::/32" in args
+        assert "interface=VPN Adapter" in args
+
+    @patch("subprocess.run")
+    def test_delete_host_route6(self, mock_run, win_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        ok = win_net.delete_host_route6("2001:db8::1")
+        assert ok
+        args = mock_run.call_args[0][0]
+        assert args[:5] == ["netsh", "interface", "ipv6", "delete", "route"]
+        assert "2001:db8::1/128" in args
+
+    @patch("subprocess.run")
+    def test_delete_net_route6(self, mock_run, win_net):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        win_net.delete_net_route6("2001:db8::/32")
+        args = mock_run.call_args[0][0]
+        assert "2001:db8::/32" in args
+
+    @patch("subprocess.run")
+    def test_set_dns6_nrpt(self, mock_run, win_net):
+        """NRPT принимает IPv6 nameserver (без скобок)."""
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        results = win_net.set_dns6(["test.local"], ["2001:db8::1"])
+        assert results["test.local"] is True
+        ps_call = mock_run.call_args_list[0]
+        ps_cmd = ps_call[0][0][2]  # powershell -Command <cmd>
+        assert "Add-DnsClientNrptRule" in ps_cmd
+        assert "'2001:db8::1'" in ps_cmd
+        assert ".test.local" in ps_cmd
+
+    @patch("subprocess.run")
+    def test_set_dns6_empty_nameservers_noop(self, mock_run, win_net):
+        """Защита M7: пустой nameservers - no-op."""
+        results = win_net.set_dns6(["test.local"], [])
+        assert results == {"test.local": False}
+        mock_run.assert_not_called()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -73,6 +73,102 @@ class TestParseTargets:
 
 
 # =========================================================================
+# IPv6 parsing (PR#2)
+# =========================================================================
+
+
+class TestParseTargetsIPv6:
+    """IPv6 CIDR/addresses парсятся в networks/hosts.
+
+    КРИТИЧНО: существующие IPv4 тесты не должны сломаться - IPv6 regex
+    добавлены ПЕРЕД hostname fallback, но ПОСЛЕ IPv4 regex (H4).
+    """
+
+    @pytest.mark.parametrize(
+        "inputs,domains,networks,hosts",
+        [
+            # CIDR IPv6
+            (["2001:db8::/32"], [], ["2001:db8::/32"], []),
+            (["fe80::/10"], [], ["fe80::/10"], []),
+            (["::/0"], [], ["::/0"], []),
+            # Адреса IPv6
+            (["2001:db8::1"], [], [], ["2001:db8::1"]),
+            (["fe80::1"], [], [], ["fe80::1"]),
+            (["::1"], [], [], ["::1"]),
+            # Full form
+            (
+                ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+                [],
+                [],
+                ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+            ),
+            # Невалидный IPv6 prefix - попадает в hostname fallback (existing flow)
+            (["2001:db8::gggg"], [], [], ["2001:db8::gggg"]),
+            # Невалидный IPv6 CIDR (prefix > 128) - отвергается, пустой результат
+            (["2001:db8::/130"], [], [], []),
+            # Mixed IPv4 + IPv6
+            (
+                ["10.0.0.0/8", "2001:db8::/32", "192.168.1.1", "fe80::1"],
+                [],
+                ["10.0.0.0/8", "2001:db8::/32"],
+                ["192.168.1.1", "fe80::1"],
+            ),
+        ],
+    )
+    def test_parse_ipv6(self, inputs, domains, networks, hosts):
+        result = parse_targets(inputs)
+        assert result.domains == domains
+        assert result.networks == networks
+        assert result.hosts == hosts
+
+    def test_ipv4_pattern_preserved(self):
+        """Backward compat: '10.0.0.0/8' идентично pre-PR (IPv4 ветка срабатывает первой)."""
+        result = parse_targets(["10.0.0.0/8"])
+        assert result.networks == ["10.0.0.0/8"]
+        assert result.hosts == []
+        assert result.domains == []
+
+    def test_hostname_with_colon_in_middle_rejected(self):
+        """'host:port' не IPv6 (есть нехекс символы) - попадает в hostname.
+
+        Regex IPv6_RE требует только [0-9a-fA-F:], поэтому 'server:port' не match.
+        Но ':' в такой строке есть - hostname regex тоже не match - попадёт в hosts
+        как bare entry (существующее поведение)."""
+        result = parse_targets(["server:8080"])
+        # 'server:8080' - не IPv4, не IPv6 (есть 's', 'r', 'v', не hex).
+        # Проходит как hostname fallback (bare string - engine попробует resolve).
+        assert "server:8080" in result.hosts
+
+    def test_ipv6_before_hostname_fallback(self):
+        """'2001:db8::1' должен попасть в hosts как IPv6, а НЕ bare hostname."""
+        result = parse_targets(["2001:db8::1"])
+        assert result.hosts == ["2001:db8::1"]
+        assert result.networks == []
+
+
+class TestValidateTargetIPv6:
+    @pytest.mark.parametrize(
+        "target,expected_kind,err_contains",
+        [
+            ("2001:db8::/32", "network", ""),
+            ("2001:db8::1", "host", ""),
+            ("fe80::1", "host", ""),
+            ("::1", "host", ""),
+            ("::/0", "network", ""),
+            ("2001:db8::/130", "", "invalid CIDR"),
+            ("2001:db8::gggg", "", "unrecognized"),
+        ],
+    )
+    def test_validate_ipv6(self, target, expected_kind, err_contains):
+        kind, err = validate_target(target)
+        assert kind == expected_kind
+        if err_contains:
+            assert err_contains in err
+        else:
+            assert err == ""
+
+
+# =========================================================================
 # validate_target
 # =========================================================================
 

--- a/tests/test_tunnel_base.py
+++ b/tests/test_tunnel_base.py
@@ -194,6 +194,112 @@ class TestTunnelPluginABC:
         dummy_plugin.net.delete_host_route.assert_called_once_with("1.2.3.4")
         dummy_plugin.net.delete_net_route.assert_called_once_with("10.0.0.0/8")
 
+    # ---- IPv6 dispatch (PR#2, H1 mitigation) ----
+
+    def test_add_routes_dispatches_ipv4_vs_ipv6_with_gateway(
+        self, make_dummy, mock_net
+    ):
+        """IPv6 CIDR/host идут в *route6 методы, IPv4 - в обычные (H1)."""
+        p = make_dummy(
+            name="mixed",
+            type="dummy",
+            routes={
+                "hosts": ["1.2.3.4", "2001:db8::1"],
+                "networks": ["10.0.0.0/8", "2001:db8::/32"],
+            },
+        )
+        p.add_routes(gateway="192.168.1.1")
+        # IPv4 через старые методы
+        mock_net.add_host_route.assert_called_once_with("1.2.3.4", "192.168.1.1")
+        mock_net.add_net_route.assert_called_once_with("10.0.0.0/8", "192.168.1.1")
+        # IPv6 через новые методы
+        mock_net.add_host_route6.assert_called_once_with("2001:db8::1", "192.168.1.1")
+        mock_net.add_net_route6.assert_called_once_with("2001:db8::/32", "192.168.1.1")
+
+    def test_add_routes_dispatches_ipv4_vs_ipv6_with_interface(
+        self, make_dummy, mock_net
+    ):
+        p = make_dummy(
+            name="tun",
+            type="dummy",
+            interface="utun99",
+            routes={
+                "hosts": ["1.2.3.4", "2001:db8::1"],
+                "networks": ["10.0.0.0/8", "2001:db8::/32"],
+            },
+        )
+        p.add_routes()
+        mock_net.add_iface_route.assert_any_call("1.2.3.4", "utun99", host=True)
+        mock_net.add_iface_route.assert_any_call("10.0.0.0/8", "utun99", host=False)
+        mock_net.add_iface_route6.assert_any_call("2001:db8::1", "utun99", host=True)
+        mock_net.add_iface_route6.assert_any_call("2001:db8::/32", "utun99", host=False)
+
+    def test_delete_routes_dispatches_ipv6(self, make_dummy, mock_net):
+        """H1: delete_routes ТОЖЕ должен dispatcher иначе IPv6 leak при disconnect."""
+        p = make_dummy(
+            name="mixed",
+            type="dummy",
+            routes={
+                "hosts": ["1.2.3.4", "2001:db8::1"],
+                "networks": ["10.0.0.0/8", "2001:db8::/32"],
+            },
+        )
+        p.delete_routes()
+        mock_net.delete_host_route.assert_called_once_with("1.2.3.4")
+        mock_net.delete_net_route.assert_called_once_with("10.0.0.0/8")
+        mock_net.delete_host_route6.assert_called_once_with("2001:db8::1")
+        mock_net.delete_net_route6.assert_called_once_with("2001:db8::/32")
+
+    def test_add_routes_invalid_network_skipped(self, make_dummy, mock_net):
+        """M8: невалидный CIDR не падает с ValueError - WARN + skip."""
+        p = make_dummy(
+            name="t",
+            type="dummy",
+            interface="utun99",
+            routes={"networks": ["not-a-cidr", "", "10.0.0.0/8"]},
+        )
+        p.add_routes()
+        # Только валидный 10.0.0.0/8 попал в add_iface_route
+        mock_net.add_iface_route.assert_called_once_with(
+            "10.0.0.0/8", "utun99", host=False
+        )
+        mock_net.add_iface_route6.assert_not_called()
+
+    def test_add_routes_invalid_host_skipped(self, make_dummy, mock_net):
+        p = make_dummy(
+            name="t",
+            type="dummy",
+            routes={"hosts": ["bad-host", "1.2.3.4"]},
+        )
+        p.add_routes(gateway="192.168.1.1")
+        mock_net.add_host_route.assert_called_once_with("1.2.3.4", "192.168.1.1")
+
+    def test_backward_compat_ipv4_only_identical(self, make_dummy, mock_net):
+        """AC8 invariant: только IPv4 config работает идентично pre-PR.
+
+        НЕ должны вызываться новые *_route6 методы при чисто IPv4 config."""
+        p = make_dummy(
+            name="v4",
+            type="dummy",
+            interface="utun99",
+            routes={"hosts": ["1.2.3.4"], "networks": ["10.0.0.0/8"]},
+        )
+        p.add_routes()
+        p.delete_routes()
+
+        # IPv4 методы вызваны
+        mock_net.add_iface_route.assert_any_call("1.2.3.4", "utun99", host=True)
+        mock_net.add_iface_route.assert_any_call("10.0.0.0/8", "utun99", host=False)
+        mock_net.delete_host_route.assert_called_once_with("1.2.3.4")
+        mock_net.delete_net_route.assert_called_once_with("10.0.0.0/8")
+
+        # IPv6 методы НЕ вызваны (только IPv4 config)
+        mock_net.add_iface_route6.assert_not_called()
+        mock_net.add_host_route6.assert_not_called()
+        mock_net.add_net_route6.assert_not_called()
+        mock_net.delete_host_route6.assert_not_called()
+        mock_net.delete_net_route6.assert_not_called()
+
     def test_default_log_path_from_cfg(self, make_dummy):
         """_default_log_path uses cfg.log when set."""
         p = make_dummy(name="test", type="dummy", log="/var/log/my.log")

--- a/tests/test_tunnel_base.py
+++ b/tests/test_tunnel_base.py
@@ -250,29 +250,34 @@ class TestTunnelPluginABC:
         mock_net.delete_host_route6.assert_called_once_with("2001:db8::1")
         mock_net.delete_net_route6.assert_called_once_with("2001:db8::/32")
 
-    def test_add_routes_invalid_network_skipped(self, make_dummy, mock_net):
-        """M8: невалидный CIDR не падает с ValueError - WARN + skip."""
+    def test_add_routes_invalid_cidr_routed_as_v4(self, make_dummy, mock_net):
+        """M8: невалидный CIDR НЕ падает с ValueError - идёт в IPv4 методы
+        (backward compat с pre-PR: add_net_route молча вернёт False).
+
+        НЕ в *_route6 методы - это важно: мусор никогда не попадает в IPv6 dispatch."""
         p = make_dummy(
             name="t",
             type="dummy",
             interface="utun99",
-            routes={"networks": ["not-a-cidr", "", "10.0.0.0/8"]},
+            routes={"networks": ["not-a-cidr", "10.0.0.0/8"]},
         )
         p.add_routes()
-        # Только валидный 10.0.0.0/8 попал в add_iface_route
-        mock_net.add_iface_route.assert_called_once_with(
-            "10.0.0.0/8", "utun99", host=False
-        )
+        # Обе записи попали в add_iface_route (IPv4 метод)
+        assert mock_net.add_iface_route.call_count == 2
         mock_net.add_iface_route6.assert_not_called()
 
-    def test_add_routes_invalid_host_skipped(self, make_dummy, mock_net):
+    def test_add_routes_hostname_goes_to_ipv4(self, make_dummy, mock_net):
+        """Backward compat: hostname (не IP) идёт в IPv4 add_host_route - engine
+        resolve его через net.resolve_host. НЕ в add_host_route6."""
         p = make_dummy(
             name="t",
             type="dummy",
-            routes={"hosts": ["bad-host", "1.2.3.4"]},
+            routes={"hosts": ["git.test.local", "1.2.3.4"]},
         )
         p.add_routes(gateway="192.168.1.1")
-        mock_net.add_host_route.assert_called_once_with("1.2.3.4", "192.168.1.1")
+        mock_net.add_host_route.assert_any_call("git.test.local", "192.168.1.1")
+        mock_net.add_host_route.assert_any_call("1.2.3.4", "192.168.1.1")
+        mock_net.add_host_route6.assert_not_called()
 
     def test_backward_compat_ipv4_only_identical(self, make_dummy, mock_net):
         """AC8 invariant: только IPv4 config работает идентично pre-PR.

--- a/tv/killswitch.py
+++ b/tv/killswitch.py
@@ -22,7 +22,16 @@ from tv.net import _run
 
 
 def _is_valid_ip(s: str) -> bool:
-    """Validate IPv4 address (no CIDR)."""
+    """Validate IP address (IPv4 или IPv6, без CIDR)."""
+    try:
+        ipaddress.ip_address(s)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_ipv4(s: str) -> bool:
+    """Validate IPv4 address (строго IPv4, без CIDR)."""
     try:
         ipaddress.IPv4Address(s)
         return True
@@ -30,10 +39,37 @@ def _is_valid_ip(s: str) -> bool:
         return False
 
 
+def _is_valid_ipv6(s: str) -> bool:
+    """Validate IPv6 address (строго IPv6, без CIDR)."""
+    try:
+        ipaddress.IPv6Address(s)
+        return True
+    except ValueError:
+        return False
+
+
 def _is_valid_network(s: str) -> bool:
-    """Validate IPv4 network in CIDR notation."""
+    """Validate network in CIDR notation (IPv4 или IPv6)."""
+    try:
+        ipaddress.ip_network(s, strict=False)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_ipv4_network(s: str) -> bool:
+    """Validate IPv4 network in CIDR notation (строго IPv4)."""
     try:
         ipaddress.IPv4Network(s, strict=False)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_ipv6_network(s: str) -> bool:
+    """Validate IPv6 network in CIDR notation (строго IPv6)."""
+    try:
+        ipaddress.IPv6Network(s, strict=False)
         return True
     except ValueError:
         return False
@@ -75,6 +111,30 @@ def _sanitize_ifaces(ifaces: list[str], log_fn=None) -> list[str]:
         elif log_fn:
             log_fn("WARN", f"rejected invalid interface: {i!r}")
     return result
+
+
+def _split_by_family(ips: list[str]) -> tuple[list[str], list[str]]:
+    """Разделить список IP на (ipv4, ipv6). Игнорирует уже невалидные."""
+    v4: list[str] = []
+    v6: list[str] = []
+    for ip in ips:
+        if _is_valid_ipv4(ip):
+            v4.append(ip)
+        elif _is_valid_ipv6(ip):
+            v6.append(ip)
+    return v4, v6
+
+
+def _split_networks_by_family(nets: list[str]) -> tuple[list[str], list[str]]:
+    """Разделить список CIDR на (ipv4, ipv6). Игнорирует невалидные."""
+    v4: list[str] = []
+    v6: list[str] = []
+    for n in nets:
+        if _is_valid_ipv4_network(n):
+            v4.append(n)
+        elif _is_valid_ipv6_network(n):
+            v6.append(n)
+    return v4, v6
 
 
 # ---------------------------------------------------------------------------

--- a/tv/killswitch.py
+++ b/tv/killswitch.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 import ipaddress
 import platform
 import re
+import shutil
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from tv import ui
 from tv.logger import Logger
 from tv.net import _run
 
@@ -161,8 +163,13 @@ class KillSwitch(ABC):
         vpn_server_ips: list[str],
         bypass_ips: list[str],
         bypass_networks: list[str],
+        ipv6_enabled: bool = False,
     ) -> bool:
-        """Apply firewall rules. Returns True on success."""
+        """Apply firewall rules. Returns True on success.
+
+        ipv6_enabled=False (default) - backward compat: существующие вызовы
+        (engine.py и тесты) работают идентично pre-PR, IPv6 rules не применяются.
+        ipv6_enabled=True - применяются IPv6 block rules (ip6tables/pfctl inet6/netsh IPv6)."""
 
     @abstractmethod
     def disable(self) -> bool:
@@ -206,6 +213,7 @@ class DarwinKillSwitch(KillSwitch):
         vpn_server_ips: list[str],
         bypass_ips: list[str],
         bypass_networks: list[str],
+        ipv6_enabled: bool = False,
     ) -> bool:
         vpn_interfaces, vpn_server_ips, bypass_ips, bypass_networks = self._sanitize(
             vpn_interfaces=vpn_interfaces,
@@ -213,11 +221,20 @@ class DarwinKillSwitch(KillSwitch):
             bypass_ips=bypass_ips,
             bypass_networks=bypass_networks,
         )
+        # Разделяем на IPv4/IPv6 для раздельных pfctl inet/inet6 правил
+        v4_server_ips, v6_server_ips = _split_by_family(vpn_server_ips)
+        v4_bypass_ips, v6_bypass_ips = _split_by_family(bypass_ips)
+        v4_bypass_nets, v6_bypass_nets = _split_networks_by_family(bypass_networks)
+
         rules = _build_pf_rules(
             vpn_interfaces=vpn_interfaces,
-            vpn_server_ips=vpn_server_ips,
-            bypass_ips=bypass_ips,
-            bypass_networks=bypass_networks,
+            vpn_server_ips=v4_server_ips,
+            bypass_ips=v4_bypass_ips,
+            bypass_networks=v4_bypass_nets,
+            ipv6_enabled=ipv6_enabled,
+            vpn_server_ips6=v6_server_ips,
+            bypass_ips6=v6_bypass_ips,
+            bypass_networks6=v6_bypass_nets,
         )
 
         # Load rules into anchor
@@ -297,8 +314,20 @@ def _build_pf_rules(
     vpn_server_ips: list[str],
     bypass_ips: list[str],
     bypass_networks: list[str],
+    ipv6_enabled: bool = False,
+    vpn_server_ips6: Optional[list[str]] = None,
+    bypass_ips6: Optional[list[str]] = None,
+    bypass_networks6: Optional[list[str]] = None,
 ) -> str:
-    """Build pf rules for kill switch anchor."""
+    """Build pf rules for kill switch anchor.
+
+    ipv6_enabled=False (default): идентично pre-PR - только inet правила.
+    ipv6_enabled=True: добавляются inet6 правила параллельно + block in/out inet6 all.
+    """
+    vpn_server_ips6 = vpn_server_ips6 or []
+    bypass_ips6 = bypass_ips6 or []
+    bypass_networks6 = bypass_networks6 or []
+
     lines: list[str] = [
         "# tunnelvault kill switch - auto-generated, do not edit",
         "# Allow loopback (in + out)",
@@ -329,6 +358,19 @@ def _build_pf_rules(
     for iface in vpn_interfaces:
         lines.append(f"pass quick on {iface} all")
 
+    # --- IPv6 outbound rules (только при ipv6_enabled=True) ---
+    if ipv6_enabled:
+        for ip in vpn_server_ips6:
+            lines.append(f"pass out quick inet6 proto {{ tcp, udp }} to {ip}")
+        for ip in bypass_ips6:
+            lines.append(f"pass out quick inet6 to {ip}")
+        for net in bypass_networks6:
+            lines.append(f"pass out quick inet6 to {net}")
+        # DHCPv6 (ULA/link-local)
+        lines.append("pass out quick inet6 proto udp from any port 546 to any port 547")
+        # Allow DNS IPv6 loopback
+        lines.append("pass out quick inet6 proto { tcp, udp } to ::1 port 53")
+
     # --- Inbound rules ---
 
     # Allow inbound from VPN server IPs (tunnel establishment responses)
@@ -338,9 +380,18 @@ def _build_pf_rules(
     # Allow DHCP responses
     lines.append("pass in quick inet proto udp from any port 67 to any port 68")
 
+    # --- IPv6 inbound rules ---
+    if ipv6_enabled:
+        for ip in vpn_server_ips6:
+            lines.append(f"pass in quick inet6 proto {{ tcp, udp }} from {ip}")
+        lines.append("pass in quick inet6 proto udp from any port 547 to any port 546")
+
     # Block everything else (out + in)
     lines.append("block out inet all")
     lines.append("block in inet all")
+    if ipv6_enabled:
+        lines.append("block out inet6 all")
+        lines.append("block in inet6 all")
 
     return "\n".join(lines) + "\n"
 
@@ -354,7 +405,11 @@ _IPTABLES_CHAIN_IN = "TUNNELVAULT_KS_IN"
 
 
 class LinuxKillSwitch(KillSwitch):
-    """Linux kill switch using iptables chains on OUTPUT and INPUT."""
+    """Linux kill switch using iptables chains on OUTPUT and INPUT.
+
+    Для IPv6 (ipv6_enabled=True): параллельные ip6tables цепочки с теми же именами.
+    shutil.which('ip6tables') guard - если отсутствует (Alpine, minimal), выводим
+    visible warning вместо silent skip (M6)."""
 
     def enable(
         self,
@@ -363,6 +418,7 @@ class LinuxKillSwitch(KillSwitch):
         vpn_server_ips: list[str],
         bypass_ips: list[str],
         bypass_networks: list[str],
+        ipv6_enabled: bool = False,
     ) -> bool:
         vpn_interfaces, vpn_server_ips, bypass_ips, bypass_networks = self._sanitize(
             vpn_interfaces=vpn_interfaces,
@@ -370,6 +426,14 @@ class LinuxKillSwitch(KillSwitch):
             bypass_ips=bypass_ips,
             bypass_networks=bypass_networks,
         )
+        # Разделяем IPv4/IPv6 для раздельных iptables/ip6tables правил
+        v4_server_ips, v6_server_ips = _split_by_family(vpn_server_ips)
+        v4_bypass_ips, v6_bypass_ips = _split_by_family(bypass_ips)
+        v4_bypass_nets, v6_bypass_nets = _split_networks_by_family(bypass_networks)
+        # Для backward compat: оригинальный iptables только IPv4 IP/net (как pre-PR)
+        vpn_server_ips = v4_server_ips
+        bypass_ips = v4_bypass_ips
+        bypass_networks = v4_bypass_nets
         # Clean up any previous rules first
         self._flush_chain()
 
@@ -534,12 +598,168 @@ class LinuxKillSwitch(KillSwitch):
         # Insert jump to our chain at the top of INPUT
         _run(["sudo", "iptables", "-I", "INPUT", "1", "-j", _IPTABLES_CHAIN_IN])
 
+        # --- IPv6: ip6tables зеркальные цепочки (опционально) ---
+        if ipv6_enabled:
+            if not shutil.which("ip6tables"):
+                # M6: visible warn (не silent). Пользователь должен знать что
+                # IPv6 killswitch недоступен, несмотря на ipv6=true.
+                msg = (
+                    "IPv6 killswitch unavailable - ip6tables missing. "
+                    "Install iptables-ipv6 package or disable ipv6 in config."
+                )
+                self._log("WARN", msg)
+                try:
+                    ui.warn(msg)
+                except Exception:
+                    pass
+            else:
+                self._apply_ip6tables(
+                    vpn_server_ips6=v6_server_ips,
+                    bypass_ips6=v6_bypass_ips,
+                    bypass_networks6=v6_bypass_nets,
+                )
+
         self._active = True
         self._log("INFO", "enabled (iptables)")
         return True
 
+    def _apply_ip6tables(
+        self,
+        *,
+        vpn_server_ips6: list[str],
+        bypass_ips6: list[str],
+        bypass_networks6: list[str],
+    ) -> None:
+        """Параллельно iptables: ip6tables chains для IPv6 трафика.
+
+        Схема зеркалирует IPv4: OUTPUT/INPUT chains, loopback allow, VPN server
+        allow, bypass allow, VPN interface wildcards (tun+/ppp+), DROP fallback."""
+        # Flush предыдущие ip6tables chains (идемпотентно)
+        _run(["sudo", "ip6tables", "-D", "OUTPUT", "-j", _IPTABLES_CHAIN])
+        _run(["sudo", "ip6tables", "-D", "INPUT", "-j", _IPTABLES_CHAIN_IN])
+        _run(["sudo", "ip6tables", "-F", _IPTABLES_CHAIN])
+        _run(["sudo", "ip6tables", "-X", _IPTABLES_CHAIN])
+        _run(["sudo", "ip6tables", "-F", _IPTABLES_CHAIN_IN])
+        _run(["sudo", "ip6tables", "-X", _IPTABLES_CHAIN_IN])
+
+        # --- OUTPUT chain ---
+        _run(["sudo", "ip6tables", "-N", _IPTABLES_CHAIN])
+        _run(["sudo", "ip6tables", "-A", _IPTABLES_CHAIN, "-o", "lo", "-j", "ACCEPT"])
+        for ip in vpn_server_ips6:
+            _run(["sudo", "ip6tables", "-A", _IPTABLES_CHAIN, "-d", ip, "-j", "ACCEPT"])
+        for ip in bypass_ips6:
+            _run(["sudo", "ip6tables", "-A", _IPTABLES_CHAIN, "-d", ip, "-j", "ACCEPT"])
+        for net in bypass_networks6:
+            _run(
+                [
+                    "sudo",
+                    "ip6tables",
+                    "-A",
+                    _IPTABLES_CHAIN,
+                    "-d",
+                    net,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+        # DHCPv6
+        _run(
+            [
+                "sudo",
+                "ip6tables",
+                "-A",
+                _IPTABLES_CHAIN,
+                "-p",
+                "udp",
+                "--sport",
+                "546",
+                "--dport",
+                "547",
+                "-j",
+                "ACCEPT",
+            ]
+        )
+        # Allow VPN interface families
+        for prefix in ("tun+", "ppp+"):
+            _run(
+                [
+                    "sudo",
+                    "ip6tables",
+                    "-A",
+                    _IPTABLES_CHAIN,
+                    "-o",
+                    prefix,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+        _run(["sudo", "ip6tables", "-A", _IPTABLES_CHAIN, "-j", "DROP"])
+        _run(["sudo", "ip6tables", "-I", "OUTPUT", "1", "-j", _IPTABLES_CHAIN])
+
+        # --- INPUT chain ---
+        _run(["sudo", "ip6tables", "-N", _IPTABLES_CHAIN_IN])
+        _run(
+            [
+                "sudo",
+                "ip6tables",
+                "-A",
+                _IPTABLES_CHAIN_IN,
+                "-i",
+                "lo",
+                "-j",
+                "ACCEPT",
+            ]
+        )
+        for prefix in ("tun+", "ppp+"):
+            _run(
+                [
+                    "sudo",
+                    "ip6tables",
+                    "-A",
+                    _IPTABLES_CHAIN_IN,
+                    "-i",
+                    prefix,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+        for ip in vpn_server_ips6:
+            _run(
+                [
+                    "sudo",
+                    "ip6tables",
+                    "-A",
+                    _IPTABLES_CHAIN_IN,
+                    "-s",
+                    ip,
+                    "-j",
+                    "ACCEPT",
+                ]
+            )
+        _run(
+            [
+                "sudo",
+                "ip6tables",
+                "-A",
+                _IPTABLES_CHAIN_IN,
+                "-p",
+                "udp",
+                "--sport",
+                "547",
+                "--dport",
+                "546",
+                "-j",
+                "ACCEPT",
+            ]
+        )
+        _run(["sudo", "ip6tables", "-A", _IPTABLES_CHAIN_IN, "-j", "DROP"])
+        _run(["sudo", "ip6tables", "-I", "INPUT", "1", "-j", _IPTABLES_CHAIN_IN])
+
     def disable(self) -> bool:
         ok = self._flush_chain()
+        # Также чистим ip6tables chains (безопасно - silent fail если нет)
+        if shutil.which("ip6tables"):
+            self._flush_chain6()
         self._active = False
         self._log("INFO", "disabled (iptables)")
         return ok
@@ -559,6 +779,18 @@ class LinuxKillSwitch(KillSwitch):
         ok2 = r2.returncode == 0 or "No chain" in (r2.stderr or "")
         return ok1 and ok2
 
+    def _flush_chain6(self) -> bool:
+        """Cleanup ip6tables chains (best-effort, silent)."""
+        _run(["sudo", "ip6tables", "-D", "OUTPUT", "-j", _IPTABLES_CHAIN])
+        _run(["sudo", "ip6tables", "-D", "INPUT", "-j", _IPTABLES_CHAIN_IN])
+        _run(["sudo", "ip6tables", "-F", _IPTABLES_CHAIN])
+        r1 = _run(["sudo", "ip6tables", "-X", _IPTABLES_CHAIN])
+        _run(["sudo", "ip6tables", "-F", _IPTABLES_CHAIN_IN])
+        r2 = _run(["sudo", "ip6tables", "-X", _IPTABLES_CHAIN_IN])
+        ok1 = r1.returncode == 0 or "No chain" in (r1.stderr or "")
+        ok2 = r2.returncode == 0 or "No chain" in (r2.stderr or "")
+        return ok1 and ok2
+
 
 # ---------------------------------------------------------------------------
 # Windows - netsh advfirewall
@@ -568,7 +800,10 @@ _WIN_RULE_PREFIX = "TunnelVault-KS"
 
 
 class WindowsKillSwitch(KillSwitch):
-    """Windows kill switch using netsh advfirewall rules."""
+    """Windows kill switch using netsh advfirewall rules.
+
+    Для IPv6 (ipv6_enabled=True): дополнительно AllowLoopbackIPv6 (::1/128)
+    и AllowVPNServers6 (remoteip принимает IPv6 без скобок)."""
 
     def enable(
         self,
@@ -577,6 +812,7 @@ class WindowsKillSwitch(KillSwitch):
         vpn_server_ips: list[str],
         bypass_ips: list[str],
         bypass_networks: list[str],
+        ipv6_enabled: bool = False,
     ) -> bool:
         vpn_interfaces, vpn_server_ips, bypass_ips, bypass_networks = self._sanitize(
             vpn_interfaces=vpn_interfaces,
@@ -584,6 +820,13 @@ class WindowsKillSwitch(KillSwitch):
             bypass_ips=bypass_ips,
             bypass_networks=bypass_networks,
         )
+        # Разделяем для raw IPv4 / IPv6 allow lists
+        v4_server_ips, v6_server_ips = _split_by_family(vpn_server_ips)
+        v4_bypass_ips, v6_bypass_ips = _split_by_family(bypass_ips)
+        v4_bypass_nets, v6_bypass_nets = _split_networks_by_family(bypass_networks)
+        vpn_server_ips = v4_server_ips
+        bypass_ips = v4_bypass_ips
+        bypass_networks = v4_bypass_nets
         # Clean up previous rules
         self.disable()
 
@@ -735,6 +978,81 @@ class WindowsKillSwitch(KillSwitch):
             ]
         )
 
+        # --- IPv6 rules ---
+        # M9: IPv6 loopback (::1/128) - всегда разрешаем, независимо от ipv6_enabled.
+        # Приложения часто используют IPv6 localhost - блокировка сломает их.
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-AllowLoopback6",
+                "dir=out",
+                "action=allow",
+                "remoteip=::1/128",
+            ]
+        )
+        _run(
+            [
+                "netsh",
+                "advfirewall",
+                "firewall",
+                "add",
+                "rule",
+                f"name={_WIN_RULE_PREFIX}-AllowLoopback6In",
+                "dir=in",
+                "action=allow",
+                "remoteip=::1/128",
+            ]
+        )
+
+        if ipv6_enabled:
+            # Allow IPv6 VPN servers (netsh remoteip принимает IPv6 без скобок)
+            if v6_server_ips:
+                _run(
+                    [
+                        "netsh",
+                        "advfirewall",
+                        "firewall",
+                        "add",
+                        "rule",
+                        f"name={_WIN_RULE_PREFIX}-AllowVPNServers6",
+                        "dir=out",
+                        "action=allow",
+                        f"remoteip={','.join(v6_server_ips)}",
+                    ]
+                )
+                _run(
+                    [
+                        "netsh",
+                        "advfirewall",
+                        "firewall",
+                        "add",
+                        "rule",
+                        f"name={_WIN_RULE_PREFIX}-AllowVPNServers6In",
+                        "dir=in",
+                        "action=allow",
+                        f"remoteip={','.join(v6_server_ips)}",
+                    ]
+                )
+            allow6_list = v6_bypass_ips + v6_bypass_nets
+            if allow6_list:
+                _run(
+                    [
+                        "netsh",
+                        "advfirewall",
+                        "firewall",
+                        "add",
+                        "rule",
+                        f"name={_WIN_RULE_PREFIX}-AllowBypass6",
+                        "dir=out",
+                        "action=allow",
+                        f"remoteip={','.join(allow6_list)}",
+                    ]
+                )
+
         self._active = True
         self._log("INFO", "enabled (netsh)")
         return True
@@ -760,6 +1078,12 @@ class WindowsKillSwitch(KillSwitch):
             "AllowLoopbackIn",
             "AllowVPNServersIn",
             "AllowDHCPIn",
+            # IPv6 rules (PR#2)
+            "AllowLoopback6",
+            "AllowLoopback6In",
+            "AllowVPNServers6",
+            "AllowVPNServers6In",
+            "AllowBypass6",
         ):
             _run(
                 [

--- a/tv/net.py
+++ b/tv/net.py
@@ -70,6 +70,36 @@ class NetManager(ABC):
     @abstractmethod
     def add_iface_route(self, target: str, iface: str, host: bool = True) -> bool: ...
 
+    # ---- IPv6 primitives (PR#2 IPv6 foundation) ----
+    # Default: no-op для backward compat. Реализации Darwin/Linux/Windows переопределяют.
+    # На Darwin add_iface_route6 НЕ использует ppp_peer (IPv4-only) - сразу
+    # -interface <utun*> для TUN интерфейсов. На Linux используется
+    # 'ip -6 route replace' (не add) - безопаснее для ::/0 при наличии RA.
+
+    def add_host_route6(self, ip: str, gateway: str) -> bool:
+        return False
+
+    def add_net_route6(self, network: str, gateway: str) -> bool:
+        return False
+
+    def add_iface_route6(self, target: str, iface: str, host: bool = True) -> bool:
+        return False
+
+    def delete_host_route6(self, ip: str) -> bool:
+        return False
+
+    def delete_net_route6(self, network: str) -> bool:
+        return False
+
+    def set_dns6(
+        self,
+        domains: list[str],
+        nameservers: list[str],
+        interface: str = "",
+    ) -> dict[str, bool]:
+        """Set IPv6-nameservers для доменов. Пустой nameservers - no-op (не сбрасывает)."""
+        return {d: False for d in domains}
+
     @abstractmethod
     def setup_dns_resolver(
         self,
@@ -348,6 +378,64 @@ class DarwinNet(NetManager):
         r = _run(["sudo", "route", "delete", "-net", network])
         return r.returncode == 0
 
+    # ---- IPv6 primitives ----
+
+    def add_host_route6(self, ip: str, gateway: str) -> bool:
+        r = _run(["sudo", "route", "add", "-inet6", "-host", ip, gateway])
+        return r.returncode == 0
+
+    def add_net_route6(self, network: str, gateway: str) -> bool:
+        r = _run(["sudo", "route", "add", "-inet6", "-net", network, gateway])
+        return r.returncode == 0
+
+    def add_iface_route6(self, target: str, iface: str, host: bool = True) -> bool:
+        """На Darwin IPv6 route через TUN: -inet6 -host/-net <target> -interface <iface>.
+
+        НЕ использует ppp_peer (IPv4-only: парсит 'inet X --> Y'). Для IPv6
+        на утилитах macOS 'route add -inet6 <cidr> -interface utunN' работает
+        без gateway - ядро автоматически находит next-hop через interface.
+        """
+        flag = "-host" if host else "-net"
+        r = _run(["sudo", "route", "add", "-inet6", flag, target, "-interface", iface])
+        return r.returncode == 0
+
+    def delete_host_route6(self, ip: str) -> bool:
+        r = _run(["sudo", "route", "delete", "-inet6", "-host", ip])
+        return r.returncode == 0
+
+    def delete_net_route6(self, network: str) -> bool:
+        r = _run(["sudo", "route", "delete", "-inet6", "-net", network])
+        return r.returncode == 0
+
+    def set_dns6(
+        self,
+        domains: list[str],
+        nameservers: list[str],
+        interface: str = "",
+    ) -> dict[str, bool]:
+        """Пишет IPv6 nameserver в /etc/resolver/<domain>.
+
+        macOS BIND resolver формат: 'nameserver 2001:db8::1' без скобок.
+        Пустой nameservers - no-op (не сбрасывает существующий файл).
+        """
+        if not nameservers:
+            return {d: False for d in domains}
+        resolver_dir = cfg.paths.resolver_dir
+        _run(["sudo", "mkdir", "-p", resolver_dir])
+        content = (
+            "# tunnelvault\n"
+            + "\n".join(f"nameserver {ns}" for ns in nameservers)
+            + "\n"
+        )
+        results: dict[str, bool] = {}
+        for domain in domains:
+            r = _run(
+                ["sudo", "tee", f"{resolver_dir}/{domain}"],
+                input=content,
+            )
+            results[domain] = r.returncode == 0
+        return results
+
     def route_table(self, lines: int | None = None) -> str:
         if lines is None:
             lines = cfg.display.route_table_lines
@@ -495,6 +583,58 @@ class LinuxNet(NetManager):
     def delete_net_route(self, network: str) -> bool:
         r = _run(["sudo", "ip", "route", "del", network])
         return r.returncode == 0
+
+    # ---- IPv6 primitives ----
+
+    def add_host_route6(self, ip: str, gateway: str) -> bool:
+        # replace вместо add: безопаснее при существующем маршруте (напр. RA ::/0).
+        r = _run(["sudo", "ip", "-6", "route", "replace", f"{ip}/128", "via", gateway])
+        return r.returncode == 0
+
+    def add_net_route6(self, network: str, gateway: str) -> bool:
+        r = _run(["sudo", "ip", "-6", "route", "replace", network, "via", gateway])
+        return r.returncode == 0
+
+    def add_iface_route6(self, target: str, iface: str, host: bool = True) -> bool:
+        t = f"{target}/128" if host else target
+        r = _run(["sudo", "ip", "-6", "route", "replace", t, "dev", iface])
+        return r.returncode == 0
+
+    def delete_host_route6(self, ip: str) -> bool:
+        r = _run(["sudo", "ip", "-6", "route", "del", f"{ip}/128"])
+        return r.returncode == 0
+
+    def delete_net_route6(self, network: str) -> bool:
+        r = _run(["sudo", "ip", "-6", "route", "del", network])
+        return r.returncode == 0
+
+    def set_dns6(
+        self,
+        domains: list[str],
+        nameservers: list[str],
+        interface: str = "",
+    ) -> dict[str, bool]:
+        """resolvectl принимает IPv6 nameservers без кавычек.
+
+        Пустой nameservers - no-op (иначе resolvectl dns iface без аргументов
+        СБРОСИТ существующие DNS для интерфейса, это не no-op).
+        """
+        results: dict[str, bool] = {d: False for d in domains}
+        if not nameservers:
+            return results
+        iface = interface
+        if not iface:
+            return results
+        if not shutil.which("resolvectl"):
+            return results
+        r = _run(["ip", "link", "show", iface])
+        if r.returncode != 0:
+            return results
+        _run(["sudo", "resolvectl", "dns", iface] + nameservers)
+        for domain in domains:
+            r3 = _run(["sudo", "resolvectl", "domain", iface, domain])
+            results[domain] = r3.returncode == 0
+        return results
 
     def route_table(self, lines: int | None = None) -> str:
         if lines is None:
@@ -804,6 +944,85 @@ class WindowsNet(NetManager):
         net_addr = network.split("/")[0] if "/" in network else network
         r = _run(["route", "DELETE", net_addr])
         return r.returncode == 0
+
+    # ---- IPv6 primitives ----
+
+    def add_host_route6(self, ip: str, gateway: str) -> bool:
+        r = _run(
+            [
+                "netsh",
+                "interface",
+                "ipv6",
+                "add",
+                "route",
+                f"{ip}/128",
+                f"nexthop={gateway}",
+            ]
+        )
+        return r.returncode == 0
+
+    def add_net_route6(self, network: str, gateway: str) -> bool:
+        if "/" not in network:
+            return False
+        r = _run(
+            [
+                "netsh",
+                "interface",
+                "ipv6",
+                "add",
+                "route",
+                network,
+                f"nexthop={gateway}",
+            ]
+        )
+        return r.returncode == 0
+
+    def add_iface_route6(self, target: str, iface: str, host: bool = True) -> bool:
+        prefix = (
+            f"{target}/128" if host else (target if "/" in target else f"{target}/128")
+        )
+        r = _run(
+            [
+                "netsh",
+                "interface",
+                "ipv6",
+                "add",
+                "route",
+                prefix,
+                f"interface={iface}",
+            ]
+        )
+        return r.returncode == 0
+
+    def delete_host_route6(self, ip: str) -> bool:
+        r = _run(["netsh", "interface", "ipv6", "delete", "route", f"{ip}/128"])
+        return r.returncode == 0
+
+    def delete_net_route6(self, network: str) -> bool:
+        if "/" not in network:
+            return False
+        r = _run(["netsh", "interface", "ipv6", "delete", "route", network])
+        return r.returncode == 0
+
+    def set_dns6(
+        self,
+        domains: list[str],
+        nameservers: list[str],
+        interface: str = "",
+    ) -> dict[str, bool]:
+        """Windows NRPT принимает IPv6 nameservers. Пустой nameservers - no-op."""
+        results: dict[str, bool] = {d: False for d in domains}
+        if not nameservers:
+            return results
+        ns_list = ",".join(f"'{ns}'" for ns in nameservers)
+        for domain in domains:
+            ps_cmd = (
+                f"Add-DnsClientNrptRule -Namespace '.{domain}' "
+                f"-NameServers {ns_list} -Comment 'tunnelvault'"
+            )
+            r = _run(["powershell", "-Command", ps_cmd])
+            results[domain] = r.returncode == 0
+        return results
 
     def route_table(self, lines: int | None = None) -> str:
         if lines is None:

--- a/tv/routing.py
+++ b/tv/routing.py
@@ -17,6 +17,11 @@ _IP_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
 _CIDR_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}/\d{1,2}$")
 _WILDCARD_RE = re.compile(r"^\*\.(.+)$")
 
+# IPv6: hex digits + ':' (минимум один ':', иначе hostname).
+# Покрывает full/compressed/scoped формы. Валидируем через ipaddress.IPv6Address.
+_IPv6_RE = re.compile(r"^[0-9a-fA-F:]+$")
+_IPv6_CIDR_RE = re.compile(r"^[0-9a-fA-F:]+/\d{1,3}$")
+
 
 @dataclass
 class ParsedTargets:
@@ -53,6 +58,23 @@ def validate_target(target: str) -> tuple[str, str]:
     if _IP_RE.match(target):
         try:
             ipaddress.ip_address(target)
+        except ValueError:
+            return "", t("routing.invalid_ip", target=target)
+        return "host", ""
+
+    # IPv6 ветки ДО hostname fallback (иначе '2001:db8::1' с двоеточиями
+    # валится в hostname - гарантированно invalid по regex, но '::1' прошёл бы
+    # raw fallback если раньше существовал).
+    if _IPv6_CIDR_RE.match(target):
+        try:
+            ipaddress.IPv6Network(target, strict=False)
+        except ValueError:
+            return "", t("routing.invalid_cidr", target=target)
+        return "network", ""
+
+    if _IPv6_RE.match(target) and ":" in target:
+        try:
+            ipaddress.IPv6Address(target)
         except ValueError:
             return "", t("routing.invalid_ip", target=target)
         return "host", ""
@@ -101,6 +123,25 @@ def parse_targets(targets: list[str]) -> ParsedTargets:
         if _IP_RE.match(entry):
             try:
                 ipaddress.ip_address(entry)
+            except ValueError:
+                continue
+            hosts.append(entry)
+            continue
+
+        # IPv6 ветки ДО fallback (H4): '2001:db8::1' содержит ':' не попадает
+        # под hostname regex, но без этих веток попал бы в hosts как raw string,
+        # а engine пытался бы resolve его через getaddrinfo.
+        if _IPv6_CIDR_RE.match(entry):
+            try:
+                ipaddress.IPv6Network(entry, strict=False)
+            except ValueError:
+                continue
+            networks.append(entry)
+            continue
+
+        if _IPv6_RE.match(entry) and ":" in entry:
+            try:
+                ipaddress.IPv6Address(entry)
             except ValueError:
                 continue
             hosts.append(entry)

--- a/tv/vpn/base.py
+++ b/tv/vpn/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import shutil
 import subprocess
 import time
@@ -15,6 +16,25 @@ from tv.app_config import cfg
 from tv.i18n import t
 from tv.logger import Logger
 from tv.net import NetManager
+
+
+def _cidr_version(cidr: str) -> Optional[int]:
+    """Безопасно определить version IP-network. None если невалидно.
+
+    M8 митигация: try/except ValueError - не падаем на плохом конфиге,
+    логирование и skip (то же поведение что add_net_route возвращает False)."""
+    try:
+        return ipaddress.ip_network(cidr, strict=False).version
+    except ValueError:
+        return None
+
+
+def _ip_version(ip: str) -> Optional[int]:
+    """Определить version IP-адреса. None если невалидно."""
+    try:
+        return ipaddress.ip_address(ip).version
+    except ValueError:
+        return None
 
 
 @dataclass
@@ -208,16 +228,29 @@ class TunnelPlugin(ABC):
             self._kill_by_pattern()
 
     def add_routes(self, gateway: Optional[str] = None) -> None:
-        """Add host and network routes from cfg.routes."""
+        """Add host and network routes from cfg.routes.
+
+        Dispatch IPv4/IPv6 через ipaddress.version (H1). Невалидный CIDR/IP -
+        WARN + skip (M8)."""
         hosts = self.cfg.routes.get("hosts", [])
         networks = self.cfg.routes.get("networks", [])
         iface = self.cfg.interface
 
         for host in hosts:
+            v = _ip_version(host)
+            if v is None:
+                self.log.log("WARN", f"invalid host (skip): {host!r}")
+                continue
             if iface:
-                ok = self.net.add_iface_route(host, iface, host=True)
+                if v == 6:
+                    ok = self.net.add_iface_route6(host, iface, host=True)
+                else:
+                    ok = self.net.add_iface_route(host, iface, host=True)
             elif gateway:
-                ok = self.net.add_host_route(host, gateway)
+                if v == 6:
+                    ok = self.net.add_host_route6(host, gateway)
+                else:
+                    ok = self.net.add_host_route(host, gateway)
             else:
                 continue
             self.log.log(
@@ -226,10 +259,20 @@ class TunnelPlugin(ABC):
             )
 
         for network in networks:
+            v = _cidr_version(network)
+            if v is None:
+                self.log.log("WARN", f"invalid network (skip): {network!r}")
+                continue
             if iface:
-                ok = self.net.add_iface_route(network, iface, host=False)
+                if v == 6:
+                    ok = self.net.add_iface_route6(network, iface, host=False)
+                else:
+                    ok = self.net.add_iface_route(network, iface, host=False)
             elif gateway:
-                ok = self.net.add_net_route(network, gateway)
+                if v == 6:
+                    ok = self.net.add_net_route6(network, gateway)
+                else:
+                    ok = self.net.add_net_route(network, gateway)
             else:
                 continue
             self.log.log(
@@ -260,8 +303,21 @@ class TunnelPlugin(ABC):
             self.net.cleanup_dns_resolver(domains, self.cfg.interface)
 
     def delete_routes(self) -> None:
-        """Remove routes added by add_routes()."""
+        """Remove routes added by add_routes().
+
+        Dispatch IPv4/IPv6 (H1): иначе IPv6 маршруты не удаляются при disconnect -
+        утечка трафика. Невалидные CIDR/IP молча skip (что добавлено невалидным,
+        того и так нет в routing table)."""
         for host in self.cfg.routes.get("hosts", []):
-            self.net.delete_host_route(host)
+            v = _ip_version(host)
+            if v == 6:
+                self.net.delete_host_route6(host)
+            elif v == 4:
+                self.net.delete_host_route(host)
+            # v is None - skip
         for network in self.cfg.routes.get("networks", []):
-            self.net.delete_net_route(network)
+            v = _cidr_version(network)
+            if v == 6:
+                self.net.delete_net_route6(network)
+            elif v == 4:
+                self.net.delete_net_route(network)

--- a/tv/vpn/base.py
+++ b/tv/vpn/base.py
@@ -230,24 +230,25 @@ class TunnelPlugin(ABC):
     def add_routes(self, gateway: Optional[str] = None) -> None:
         """Add host and network routes from cfg.routes.
 
-        Dispatch IPv4/IPv6 через ipaddress.version (H1). Невалидный CIDR/IP -
-        WARN + skip (M8)."""
+        Dispatch IPv4/IPv6 через ipaddress.version (H1). Только IPv6 маршруты
+        идут в *_route6 методы. IPv4 И hostname (non-IP) - в обычные методы
+        (backward compat: hostname-routes как git.test.local обрабатываются
+        IPv4-пайплайном, engine resolve их через net.resolve_host)."""
         hosts = self.cfg.routes.get("hosts", [])
         networks = self.cfg.routes.get("networks", [])
         iface = self.cfg.interface
 
         for host in hosts:
             v = _ip_version(host)
-            if v is None:
-                self.log.log("WARN", f"invalid host (skip): {host!r}")
-                continue
+            # v == 6 -> IPv6, v == 4 или None (hostname) -> обычные IPv4 методы
+            is_v6 = v == 6
             if iface:
-                if v == 6:
+                if is_v6:
                     ok = self.net.add_iface_route6(host, iface, host=True)
                 else:
                     ok = self.net.add_iface_route(host, iface, host=True)
             elif gateway:
-                if v == 6:
+                if is_v6:
                     ok = self.net.add_host_route6(host, gateway)
                 else:
                     ok = self.net.add_host_route(host, gateway)
@@ -260,16 +261,16 @@ class TunnelPlugin(ABC):
 
         for network in networks:
             v = _cidr_version(network)
-            if v is None:
-                self.log.log("WARN", f"invalid network (skip): {network!r}")
-                continue
+            # v == 6 -> IPv6, v == 4 или None (плохой CIDR) -> IPv4 методы
+            # (как pre-PR: add_net_route молча вернёт False для некорректного).
+            is_v6 = v == 6
             if iface:
-                if v == 6:
+                if is_v6:
                     ok = self.net.add_iface_route6(network, iface, host=False)
                 else:
                     ok = self.net.add_iface_route(network, iface, host=False)
             elif gateway:
-                if v == 6:
+                if is_v6:
                     ok = self.net.add_net_route6(network, gateway)
                 else:
                     ok = self.net.add_net_route(network, gateway)
@@ -305,19 +306,16 @@ class TunnelPlugin(ABC):
     def delete_routes(self) -> None:
         """Remove routes added by add_routes().
 
-        Dispatch IPv4/IPv6 (H1): иначе IPv6 маршруты не удаляются при disconnect -
-        утечка трафика. Невалидные CIDR/IP молча skip (что добавлено невалидным,
-        того и так нет в routing table)."""
+        Dispatch IPv4/IPv6 (H1): IPv6 в *_route6, всё остальное (IPv4 и hostname)
+        в обычные методы. Симметрично add_routes: что добавили обычным методом
+        должны удалить им же."""
         for host in self.cfg.routes.get("hosts", []):
-            v = _ip_version(host)
-            if v == 6:
+            if _ip_version(host) == 6:
                 self.net.delete_host_route6(host)
-            elif v == 4:
+            else:
                 self.net.delete_host_route(host)
-            # v is None - skip
         for network in self.cfg.routes.get("networks", []):
-            v = _cidr_version(network)
-            if v == 6:
+            if _cidr_version(network) == 6:
                 self.net.delete_net_route6(network)
-            elif v == 4:
+            else:
                 self.net.delete_net_route(network)


### PR DESCRIPTION
## Что сделано

**PR#2 из 4** IPv6 series (parent #5). Базовая инфраструктура IPv6 маршрутизации без plugin изменений.

### Что ДЕЛАЕТ
- **net.py** IPv6 primitives: `add_route6`/`del_route6`/`set_dns6` на macOS/Linux/Windows
- **routing.py** `parse_targets()` принимает IPv6 CIDR/addresses (через `ipaddress` модуль, regex gates ПЕРЕД hostname fallback)
- **killswitch.py** IPv6 rules: ip6tables TV_BLOCK chain (Linux), pfctl `inet6` (macOS), netsh IPv6 (Windows) - через `ipv6_enabled=False` kwarg (backward compat)
- **vpn/base.py** dispatch `add_routes`/`delete_routes` - автоматически выбирает v4/v6 метод по CIDR version
- **config.toml.example** - закомментированные IPv6 примеры

### Что НЕ ДЕЛАЕТ (scope discipline)
- НЕ меняет `resolve_host()` - остаётся AF_INET → PR#3
- НЕ трогает `checks.py`, `dns_proxy.py` → PR#3
- НЕ трогает plugins (кроме `vpn/base.py` dispatch) → PR#4

## User constraint compliance

**"Ничего не должно сломаться"** - выполнено через:
- `_is_valid_ip` IPv6 fix (pre-existing регрессия): раньше killswitch фильтровал IPv6 server IPs, блокируя VPN handshake при IPv6-only серверах
- `KillSwitch.enable(ipv6_enabled=False)` default kwarg - existing `engine.py:770` вызов идентичен pre-PR
- `parse_targets` IPv4 regex **первыми** - IPv4-only targets парсятся как раньше
- `add_routes`/`delete_routes` с IPv4 CIDR - идентично pre-PR (dispatch на add_route не add_route6)

## Adversarial findings (все устранены)

4 HIGH + 5 MEDIUM из devil-advocate:

| ID | Finding | Mitigation |
|----|---------|-----------|
| H1 | `delete_routes()` без IPv6 dispatch → leak при disconnect | Симметричный dispatch в `delete_routes()` (base.py) |
| H2 | `KillSwitch.enable()` signature не знает про ipv6 | `ipv6_enabled=False` kwarg + backward compat |
| H3 | `_is_valid_ip` IPv4-only → IPv6 server blocked by killswitch | `ipaddress.ip_address` - принимает оба |
| H4 | parse_targets: `2001:db8::1` проходил regex и становился "hostname" | IPv6 regex gate ПЕРЕД hostname fallback |
| M5 | Darwin `add_iface_route6` confusion с ppp_peer | Explicit docstring: прямой `-interface utunN`, без ppp |
| M6 | ip6tables absent → silent security gap | `shutil.which` guard + **visible** `ui.warn` |
| M7 | `set_dns6(nameservers=[])` → невалидный resolver | Guard `if not nameservers: return` всех платформах |
| M8 | `ip_network()` dispatch без try/except → новый exception path | try/except ValueError → log warn |
| M9 | Windows `::1` не в AllowLoopback → localhost IPv6 apps break | `::1/128` allowed всегда |

## Тесты

**95+ новых unit тестов:**
- `tests/test_net.py` + `test_net_windows.py` - 28 тестов IPv6 primitives
- `tests/test_routing.py::TestParseTargetsIPv6` - 24 теста (IPv6 CIDR, addresses, hostname-NOT-IPv6 discrimination)
- `tests/test_killswitch.py` - 29 тестов (IPv6 rules, backward compat, M6 guard, M9 loopback)
- `tests/test_tunnel_base.py` - 7 тестов dispatch (IPv4/IPv6/hostname/invalid)

## Verification phases

**Phase 1 - macOS full regression:** 1323/1325 passed (2 pre-existing keepalive flaky, не связаны). 338/338 PR#2-affected tests GREEN.

**Phase 2 - Lima native Linux aarch64:** 1319/1324 passed (5 pre-existing, все подтверждены на baseline main). 18/18 Linux-specific IPv6 тестов (`ip -6 route replace`, `ip6tables` TV_BLOCK, resolvectl IPv6 nameservers) GREEN.

**Phase 3 - Lima docker compose integration:** 61/62 passed. 1 failed (`test_two_tunnels_connect_and_both_have_interfaces`) - pre-existing flaky в Lima из-за 2CPU/2GiB ограничений (sing-box не успевает поднять TUN за 15s), на GitHub CI ubuntu-latest тот же тест PASS.

**0 регрессий PR#2.**

## Что дальше

- **PR#3 #84:** Health checks + dns_proxy (включая `resolve_host` dual-stack)
- **PR#4 #85:** Plugins (sing-box dual-stack, OpenVPN route-ipv6, etc, закроет #5)

Refs #5